### PR TITLE
fix: CI lint errors — unused import and require() style import (#37)

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { storage, type AnalysisResult } from "@/lib/storage";
+import { type AnalysisResult } from "@/lib/storage";
 import { getLocale, t, type Locale } from "@/lib/i18n";
 import { useHistory, GROUP_ORDER } from "@/hooks/useHistory";
 import { HistoryCard, INPUT_TYPE_BADGE } from "@/components/history/HistoryCard";

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -13,6 +13,8 @@
 // call sites compile; they now delegate to buildSystemPrompt with appropriate defaults.
 // ──────────────────────────────────────────────
 
+import { getDomainFocuses } from "./domainFocuses";
+
 export interface AnalysisOptions {
   usability?: boolean;
   desireAlignment?: boolean;
@@ -863,8 +865,6 @@ export function buildSystemPrompt(params: BuildSystemPromptParams): string {
 
     // Inject selected domain focus areas as concentrated observation directives
     if (domainFocuses && domainFocuses.length > 0) {
-      // Import focus definitions lazily to avoid circular deps — inline the lookup
-      const { getDomainFocuses } = require("./domainFocuses") as typeof import("./domainFocuses");
       const allFocuses = getDomainFocuses(domain);
       const selected = allFocuses.filter((f) => domainFocuses.includes(f.key));
       if (selected.length > 0) {


### PR DESCRIPTION
## Summary
- Remove unused `storage` import in `app/history/page.tsx` (lint error)
- Replace `require()` lazy-load in `lib/prompts.ts` with static `import { getDomainFocuses }` (no actual circular dep exists)
- Both `tsc --noEmit` and `npm run lint` now pass cleanly after `npm install`

## Test plan
- [ ] `npm run lint` — no errors
- [ ] `npm run type-check` — passes
- [ ] `npm run schema:validate` — all 3 contracts valid

Closes #37

https://claude.ai/code/session_01QVzVPcuYnBMFKTS8neBcDA