### PR TITLE
feat: 히스토리 트렌드 차트 — 점수 시계열 시각화

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -6,10 +6,12 @@ import { type AnalysisResult } from "@/lib/storage";
 import { getLocale, t, type Locale } from "@/lib/i18n";
 import { useHistory, GROUP_ORDER } from "@/hooks/useHistory";
 import { HistoryCard, INPUT_TYPE_BADGE } from "@/components/history/HistoryCard";
+import { TrendChart } from "@/components/history/TrendChart";
 
 export default function HistoryPage() {
   const router = useRouter();
   const [locale, setLocale] = useState<Locale>("ko");
+  const [view, setView] = useState<"list" | "trend">("list");
 
   useEffect(() => { setLocale(getLocale()); }, []);
 
@@ -59,6 +61,40 @@ export default function HistoryPage() {
         </p>
       </div>
 
+      {/* View toggle */}
+      {analyses.length > 0 && (
+        <div className="flex gap-1 mb-5">
+          <button
+            onClick={() => setView("list")}
+            className={`px-3 py-1.5 text-xs rounded-md border transition-colors ${
+              view === "list"
+                ? "bg-white/10 text-white border-white/20"
+                : "text-[var(--muted)] border-[var(--border)] hover:text-white"
+            }`}
+          >
+            목록
+          </button>
+          <button
+            onClick={() => setView("trend")}
+            className={`px-3 py-1.5 text-xs rounded-md border transition-colors ${
+              view === "trend"
+                ? "bg-white/10 text-white border-white/20"
+                : "text-[var(--muted)] border-[var(--border)] hover:text-white"
+            }`}
+          >
+            트렌드
+          </button>
+        </div>
+      )}
+
+      {/* Trend view */}
+      {view === "trend" && (
+        <TrendChart analyses={filtered} />
+      )}
+
+      {/* List view filters and cards */}
+      {view === "list" && (
+      <>
       {/* Filters — 검색 + 셀렉트 */}
       <div className="flex flex-col sm:flex-row gap-2 mb-2">
         <input
@@ -215,6 +251,8 @@ export default function HistoryPage() {
           ))
         )}
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/components/history/TrendChart.tsx
+++ b/components/history/TrendChart.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import type { AnalysisResult } from "@/lib/storage";
+
+const SERIES_COLORS = [
+  "#93c5fd",
+  "#86efac",
+  "#fca5a5",
+  "#d8b4fe",
+  "#fdba74",
+  "#67e8f9",
+  "#f0abfc",
+  "#a5f3fc",
+];
+
+interface ChartPoint {
+  date: string;
+  timestamp: number;
+  [key: string]: string | number | undefined;
+}
+
+interface TooltipPayloadEntry {
+  name: string;
+  value: number;
+  color: string;
+  payload: ChartPoint;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[#111] shadow-xl px-3 py-2.5 max-w-xs">
+      <p className="text-xs text-[var(--muted)] mb-2">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.name} className="mb-1 last:mb-0">
+          <p className="text-[11px] font-medium" style={{ color: entry.color }}>
+            {entry.name}: {entry.value}점
+          </p>
+          <p className="text-[10px] text-white/50 line-clamp-2">
+            {entry.payload[`${entry.name}__label`] as string}
+          </p>
+        </div>
+      ))}
+      <p className="text-[10px] text-white/30 mt-1.5">클릭하여 리포트 보기</p>
+    </div>
+  );
+}
+
+interface TrendChartProps {
+  analyses: AnalysisResult[];
+}
+
+export function TrendChart({ analyses }: TrendChartProps) {
+  const router = useRouter();
+
+  const { seriesKeys, data } = useMemo(() => {
+    const groups = new Map<string, AnalysisResult[]>();
+    for (const a of analyses) {
+      const key = a.projectTag || "미분류";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(a);
+    }
+    const groupEntries = Array.from(groups.entries());
+    for (const [, items] of groupEntries) {
+      items.sort((a: AnalysisResult, b: AnalysisResult) => +new Date(a.createdAt) - +new Date(b.createdAt));
+    }
+
+    const seriesKeys = Array.from(groups.keys());
+
+    type SeriesPoint = { timestamp: number; date: string; score: number; id: string; label: string };
+    const seriesData = new Map<string, SeriesPoint[]>();
+    for (const [key, items] of groupEntries) {
+      seriesData.set(
+        key,
+        items.map((a) => ({
+          timestamp: +new Date(a.createdAt),
+          date: new Date(a.createdAt).toLocaleDateString("ko-KR", {
+            month: "short",
+            day: "numeric",
+          }),
+          score: a.score,
+          id: a.id,
+          label: a.hypothesis || a.summary?.slice(0, 50) || "",
+        }))
+      );
+    }
+
+    const seriesDataEntries = Array.from(seriesData.entries());
+    const allTimestamps = Array.from(
+      new Set(
+        Array.from(seriesData.values()).flatMap((pts: SeriesPoint[]) => pts.map((p) => p.timestamp))
+      )
+    ).sort((a: number, b: number) => a - b);
+
+    const data: ChartPoint[] = allTimestamps.map((ts) => {
+      const d = new Date(ts);
+      const point: ChartPoint = {
+        date: d.toLocaleDateString("ko-KR", { month: "short", day: "numeric" }),
+        timestamp: ts,
+      };
+      for (const [key, pts] of seriesDataEntries) {
+        const match = pts.find((p) => p.timestamp === ts);
+        if (match) {
+          point[key] = match.score;
+          point[`${key}__id`] = match.id;
+          point[`${key}__label`] = match.label;
+        }
+      }
+      return point;
+    });
+
+    return { seriesKeys, data };
+  }, [analyses]);
+
+  if (data.length < 2) {
+    return (
+      <div className="text-center py-16 text-[var(--muted)]">
+        <p className="text-sm">트렌드를 표시하려면 분석이 2개 이상 필요합니다</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <ResponsiveContainer width="100%" height={320}>
+        <LineChart data={data} margin={{ top: 8, right: 16, left: -8, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 11, fill: "rgba(255,255,255,0.4)" }}
+            axisLine={{ stroke: "rgba(255,255,255,0.1)" }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 100]}
+            tick={{ fontSize: 11, fill: "rgba(255,255,255,0.4)" }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip content={<CustomTooltip />} cursor={{ stroke: "rgba(255,255,255,0.08)" }} />
+          {seriesKeys.length > 1 && (
+            <Legend
+              wrapperStyle={{
+                fontSize: 11,
+                color: "rgba(255,255,255,0.5)",
+                paddingTop: 12,
+              }}
+            />
+          )}
+          {seriesKeys.map((key, i) => (
+            <Line
+              key={key}
+              type="monotone"
+              dataKey={key}
+              stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+              strokeWidth={1.5}
+              dot={{ r: 4, fill: SERIES_COLORS[i % SERIES_COLORS.length] }}
+              activeDot={{
+                r: 6,
+                cursor: "pointer",
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                onClick: (_event: unknown, payload: any) => {
+                  const id = payload?.payload?.[`${key}__id`] as string | undefined;
+                  if (id) router.push(`/report/${id}`);
+                },
+              }}
+              connectNulls={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,7 +1579,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -2248,7 +2247,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2359,7 +2357,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2879,7 +2876,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3787,7 +3783,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4427,7 +4422,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4597,7 +4591,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5531,7 +5524,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6103,7 +6095,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6179,7 +6170,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -7114,7 +7104,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7295,7 +7284,6 @@
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -7405,7 +7393,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7418,7 +7405,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7431,15 +7417,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7554,8 +7538,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8580,7 +8563,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8652,7 +8634,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8796,7 +8777,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9194,7 +9174,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- 히스토리 페이지에 "트렌드" 뷰 토글 추가 (목록 / 트렌드)
- `projectTag`별 점수 변화를 recharts LineChart로 시계열 시각화
- 데이터 포인트 클릭 시 해당 분석 리포트(`/report/[id]`)로 이동
- 커스텀 툴팁: 날짜 + 점수 + 가설 요약 표시

Closes #45

https://claude.ai/code/session_01EbcBXxFfVumP48vyKEg2Q2