### PR TITLE
fix: prefix unused vars with _ to clear all lint warnings

### DIFF
--- a/app/api/code-to-figma/route.ts
+++ b/app/api/code-to-figma/route.ts
@@ -227,14 +227,14 @@ async function createFigmaVariables(
     : null;
 
   // Build variable create/update payload
-  const variableCreates: Array<{
+  const _variableCreates: Array<{
     action: "CREATE";
     name: string;
     variableCollectionId: string;
     resolvedType: "COLOR" | "FLOAT" | "STRING";
   }> = [];
 
-  const valueSets: Array<{
+  const _valueSets: Array<{
     action: "CREATE";
     variableId: string;
     modeId: string;
@@ -244,8 +244,8 @@ async function createFigmaVariables(
   // POST to Figma Variables batch API
   const payload: {
     variableCollections?: Array<{ action: "CREATE"; name: string; id: string }>;
-    variables?: typeof variableCreates;
-    variableModeValues?: typeof valueSets;
+    variables?: typeof _variableCreates;
+    variableModeValues?: typeof _valueSets;
   } = {};
 
   // Create collection if not exists

--- a/app/code-to-figma/page.tsx
+++ b/app/code-to-figma/page.tsx
@@ -283,7 +283,7 @@ export default function CodeToFigmaPage() {
   const [taxonomy, setTaxonomy] = useState("");
 
   // Common Figma fields
-  const [figmaUrl, setFigmaUrl] = useState("");
+  const [figmaUrl, _setFigmaUrl] = useState("");
   const [figmaToken, setFigmaToken] = useState("");
 
   // Analysis state

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -345,7 +345,7 @@ export default function DashboardPage() {
   const [insights, setInsights] = useState<Insights | null>(null);
   const [loadingInsights, setLoadingInsights] = useState(false);
   const [insightsCached, setInsightsCached] = useState(false);
-  const [insightsInsufficient, setInsightsInsufficient] = useState(false);
+  const [_insightsInsufficient, setInsightsInsufficient] = useState(false);
   const [expandedIssueIdx, setExpandedIssueIdx] = useState<number | null>(null);
 
   // Active score lines

--- a/components/InputSection.tsx
+++ b/components/InputSection.tsx
@@ -159,7 +159,7 @@ export function InputSection({
   onAnalysisOptionsChange,
   showErrors = false,
   inputReady: inputReadyProp = false,
-  contextReady: contextReadyProp = false,
+  contextReady: _contextReadyProp = false,
   productMode = "yafit",
   domain = "",
   onDomainChange,
@@ -177,7 +177,7 @@ export function InputSection({
   const [perspectiveOpen, setPerspectiveOpen] = useState(false);
   const [modeOpen, setModeOpen] = useState(false);
 
-  const { fieldErrors, inputReady, contextReady } = useInputValidation({
+  const { fieldErrors, inputReady, contextReady: _contextReady } = useInputValidation({
     mode,
     activeTab,
     hypothesis,

--- a/components/OCRReviewModal.tsx
+++ b/components/OCRReviewModal.tsx
@@ -70,6 +70,7 @@ export default function OCRReviewModal({ ocrResults, images, onConfirm, onCancel
                 {/* Thumbnail */}
                 {thumbnail && (
                   <div className="shrink-0 w-24">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={`data:image/png;base64,${thumbnail}`}
                       alt={`화면 ${result.screenIndex + 1}`}

--- a/lib/figma/artifacts.ts
+++ b/lib/figma/artifacts.ts
@@ -118,7 +118,7 @@ function arrowDef(id = "arrow", color = MUTED): string {
   </defs>`;
 }
 
-function arrow(
+function _arrow(
   x1: number, y1: number, x2: number, y2: number,
   { color = MUTED, markerId = "arrow" }: { color?: string; markerId?: string } = {}
 ): string {
@@ -453,7 +453,7 @@ export function generateTaxonomySVG(eventTaxonomy: EventTaxonomyItem[]): string 
   const PAD = 40;
   const COL1 = 180; // screen name col width
   const COL2 = 380; // events col width
-  const COL3 = 240; // next screens col width
+  const _COL3 = 240; // next screens col width
   const ROW_H_BASE = 48;
   const parts: string[] = [];
   let y = 64;

--- a/lib/figma/claudeDesignBridge.ts
+++ b/lib/figma/claudeDesignBridge.ts
@@ -95,7 +95,7 @@ async function generateWithRestApi(
 // ─── Claude Design API provider (stub — implement when API launches) ──────────
 
 async function generateWithClaudeDesign(
-  input: DesignGeneratorInput,
+  _input: DesignGeneratorInput,
 ): Promise<DesignGeneratorOutput> {
   // ── TODO: Uncomment and implement when Claude Design API is available ────────
   //

--- a/lib/ocr.ts
+++ b/lib/ocr.ts
@@ -129,7 +129,7 @@ function clampElement(el: OCRElement): OCRElement {
 export async function extractTextFromImages(
   base64Images: string[],
   apiKey?: string,
-  productMode?: string
+  _productMode?: string
 ): Promise<OCRResult[]> {
   const key = apiKey || process.env.ANTHROPIC_API_KEY;
   if (!key) throw new Error("ANTHROPIC_API_KEY is not set.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,7 +1579,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -2248,7 +2247,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2359,7 +2357,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2879,7 +2876,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3787,7 +3783,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4427,7 +4422,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4597,7 +4591,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5531,7 +5524,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6103,7 +6095,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6179,7 +6170,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -7114,7 +7104,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7295,7 +7284,6 @@
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -7405,7 +7393,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7418,7 +7405,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7431,15 +7417,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7554,8 +7538,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8580,7 +8563,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8652,7 +8634,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -8796,7 +8777,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9194,7 +9174,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Prefix unused variables with `_` across 8 files to clear all ESLint `unused-imports/no-unused-vars` warnings
- Add `eslint-disable-next-line` for base64 `<img>` in `OCRReviewModal.tsx`
- TypeScript and lint now pass with zero warnings/errors

Closes #58

https://claude.ai/code/session_01D6ksQaxMphnSx8yKVgDzxY