### PR TITLE
fix: remove ?tab= param when switching to overview tab

### DIFF
--- a/components/ReportTabs.tsx
+++ b/components/ReportTabs.tsx
@@ -71,7 +71,11 @@ export function ReportTabs({ data, locale }: { data: AnalysisResult; locale: Loc
   const handleTabChange = useCallback((newTab: Tab) => {
     setTab(newTab);
     const url = new URL(window.location.href);
-    url.searchParams.set("tab", newTab);
+    if (newTab === "overview") {
+      url.searchParams.delete("tab");
+    } else {
+      url.searchParams.set("tab", newTab);
+    }
     window.history.replaceState(null, "", url.toString());
   }, []);
 


### PR DESCRIPTION
## Summary

- When switching to the `overview` tab, `?tab=` query param is now deleted from the URL (clean `/report/[id]` URL)
- Other tabs (`thinkAloud`, `flow`, `issues`) continue to set `?tab=<name>` as before
- `handleTabChange` already existed and fired on every tab click — only the `overview` branch needed adding

Closes #66

https://claude.ai/code/session_01T41CoV7Dv6b8zSP5v8JBeN