### PR TITLE
feat: 리포트 페이지 이전/다음 분석 네비게이션 버튼 (#75)

### DIFF
--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -20,6 +20,8 @@ export default function ReportPage() {
   const [notFound, setNotFound] = useState(false);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [roundNumber, setRoundNumber] = useState(1);
+  const [prevId, setPrevId] = useState<string | null>(null);
+  const [nextId, setNextId] = useState<string | null>(null);
 
   const handleReanalyze = useCallback((analysis: AnalysisResult) => {
     const reanalyzeParams = {
@@ -62,6 +64,31 @@ export default function ReportPage() {
       });
   }, [params.id]);
 
+  useEffect(() => {
+    const id = params.id as string;
+
+    const computeNav = (allAnalyses: { id: string; createdAt: string }[]) => {
+      const sorted = [...allAnalyses].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+      const allIds = sorted.map((r) => r.id);
+      const idx = allIds.indexOf(id);
+      setPrevId(idx > 0 ? allIds[idx - 1] : null);
+      setNextId(idx < allIds.length - 1 ? allIds[idx + 1] : null);
+    };
+
+    fetch("/api/history")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.analyses && data.analyses.length > 0) {
+          computeNav(data.analyses);
+        } else {
+          computeNav(storage.getAll());
+        }
+      })
+      .catch(() => computeNav(storage.getAll()));
+  }, [params.id]);
+
   if (notFound) {
     return (
       <div className="p-8">
@@ -99,6 +126,32 @@ export default function ReportPage() {
             >
               ← {t("backToHistory", locale)}
             </Link>
+            <button
+              onClick={() => prevId && router.push(`/report/${prevId}`)}
+              disabled={!prevId}
+              className={[
+                "text-sm transition-colors",
+                !prevId
+                  ? "opacity-40 cursor-not-allowed text-[var(--muted)]"
+                  : "text-[var(--muted)] hover:text-white",
+              ].join(" ")}
+            >
+              <span className="md:hidden">←</span>
+              <span className="hidden md:inline">← 이전</span>
+            </button>
+            <button
+              onClick={() => nextId && router.push(`/report/${nextId}`)}
+              disabled={!nextId}
+              className={[
+                "text-sm transition-colors",
+                !nextId
+                  ? "opacity-40 cursor-not-allowed text-[var(--muted)]"
+                  : "text-[var(--muted)] hover:text-white",
+              ].join(" ")}
+            >
+              <span className="md:hidden">→</span>
+              <span className="hidden md:inline">다음 →</span>
+            </button>
             <Link
               href="/"
               className="text-sm text-[var(--muted)] hover:text-white transition-colors"


### PR DESCRIPTION
## Summary

- `/report/[id]` 헤더에 `← 이전` / `다음 →` 버튼 추가
- `/api/history` → `localStorage` 폴백 순으로 전체 분석 목록을 가져와 현재 ID의 인접 항목을 계산
- 비활성 상태: `opacity-40 cursor-not-allowed` 적용
- 모바일(768px 미만): 텍스트 없이 `←` / `→` 아이콘만 표시

## Test plan

- [ ] 분석이 2개 이상일 때 이전/다음 버튼이 올바른 리포트로 이동하는지 확인
- [ ] 첫 번째(최신) 분석에서 `← 이전` 비활성화, 마지막(오래된) 분석에서 `다음 →` 비활성화 확인
- [ ] 비활성 버튼 클릭 시 동작 없음 확인
- [ ] 모바일 뷰포트(< 768px)에서 아이콘만 표시되는지 확인

Closes #75