### PR TITLE
fix: non-null assertion 제거 (helpers.ts, artifacts.ts)

### DIFF
--- a/components/report/helpers.ts
+++ b/components/report/helpers.ts
@@ -9,7 +9,8 @@ export function groupIssuesByScreen(
   (issues ?? []).forEach((issue, i) => {
     const screenIdx = typeof issue.screenIndex === "number" ? issue.screenIndex : 0;
     if (!map.has(screenIdx)) map.set(screenIdx, []);
-    map.get(screenIdx)!.push({
+    const screenBucket = map.get(screenIdx);
+    screenBucket?.push({
       index: i,
       severity: issue.severity,
       desireType: issue.desireType,
@@ -31,7 +32,8 @@ export function countIssuesPerScreen(issues: AnalysisResult["issues"] | undefine
   (issues ?? []).forEach((issue) => {
     const idx = typeof issue.screenIndex === "number" ? issue.screenIndex : 0;
     if (!map.has(idx)) map.set(idx, { total: 0, critical: 0 });
-    const entry = map.get(idx)!;
+    const entry = map.get(idx);
+    if (!entry) return;
     entry.total++;
     if (issue.severity === "Critical" || (issue.severity as string) === "심각") entry.critical++;
   });

--- a/lib/figma/artifacts.ts
+++ b/lib/figma/artifacts.ts
@@ -343,7 +343,7 @@ export function generateFlowSVG(userFlow: UserFlow[], screens: Screen[]): string
     allNodes.add(from);
     allNodes.add(to);
     if (!outEdges.has(from)) outEdges.set(from, []);
-    outEdges.get(from)!.push({ to, trigger });
+    outEdges.get(from)?.push({ to, trigger });
     inDegree.set(to, (inDegree.get(to) ?? 0) + 1);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7753,6 +7753,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- `components/report/helpers.ts`: `map.get()!` 패턴 2곳을 optional chaining(`?.`) 및 early-return으로 교체
- `lib/figma/artifacts.ts`: `outEdges.get(from)!.push(...)` → `outEdges.get(from)?.push(...)` 로 교체

QA 리포트 #97에서 지적된 lint 경고 3건(HIGH 우선순위) 해결.

## Test plan

- [ ] `npx tsc --noEmit` 통과 확인
- [ ] `next lint` 에서 해당 파일의 `no-non-null-assertion` 경고 없음 확인
- [ ] `groupIssuesByScreen`, `countIssuesPerScreen`, `generateFlowSVG` 동작 정상 확인

Closes #97