### PR TITLE
feat: 경쟁사 이미지+영상 분석 + 독립 분석 페이지

### DIFF
--- a/app/api/calibration/adjustments/route.ts
+++ b/app/api/calibration/adjustments/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { analyzeCalibrationTrend, buildCalibrationDirective } from "@/lib/prompt-calibration";
+import type { CalibrationRecord, SeverityLevel } from "@/lib/calibration";
+
+// GET /api/calibration/adjustments — get current calibration adjustments
+export async function GET() {
+  try {
+    const rawRecords = await prisma.calibrationRecord.findMany({
+      orderBy: { calibratedAt: "desc" },
+      take: 500,
+    });
+
+    const records: CalibrationRecord[] = rawRecords.map((r) => ({
+      id: r.id,
+      analysisId: r.analysisId,
+      criterionId: r.criterionId,
+      predictedSeverity: r.predictedSeverity as SeverityLevel,
+      actualMetric: r.actualMetric,
+      actualValue: r.actualValue,
+      accuracy: r.accuracy as CalibrationRecord["accuracy"],
+      deviation: r.deviation,
+      calibratedAt: r.calibratedAt,
+    }));
+
+    const adjustments = analyzeCalibrationTrend(records);
+    const directive = buildCalibrationDirective(adjustments);
+
+    // Summary stats
+    const totalRecords = records.length;
+    const accurateCount = records.filter((r) => r.accuracy === "accurate").length;
+    const overCount = records.filter((r) => r.accuracy === "overestimated").length;
+    const underCount = records.filter((r) => r.accuracy === "underestimated").length;
+
+    return NextResponse.json({
+      adjustments,
+      directive,
+      stats: {
+        total: totalRecords,
+        accurate: accurateCount,
+        overestimated: overCount,
+        underestimated: underCount,
+        accuracyRate: totalRecords > 0 ? accurateCount / totalRecords : null,
+      },
+    });
+  } catch (error) {
+    console.error("[calibration adjustments]", error);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/app/api/calibration/route.ts
+++ b/app/api/calibration/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import {
+  calculateAccuracy,
+  calculateDeviation,
+  type SeverityLevel,
+} from "@/lib/calibration";
+
+// GET /api/calibration — list all records
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const criterionId = searchParams.get("criterionId");
+    const analysisId = searchParams.get("analysisId");
+
+    const records = await prisma.calibrationRecord.findMany({
+      where: {
+        ...(criterionId ? { criterionId } : {}),
+        ...(analysisId ? { analysisId } : {}),
+      },
+      orderBy: { calibratedAt: "desc" },
+      take: 200,
+    });
+    return NextResponse.json(records);
+  } catch (error) {
+    console.error("[calibration GET]", error);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}
+
+// POST /api/calibration — add a calibration record manually
+export async function POST(req: NextRequest) {
+  try {
+    const { analysisId, criterionId, predictedSeverity, actualMetric, actualValue } =
+      (await req.json()) as {
+        analysisId: string;
+        criterionId: string;
+        predictedSeverity: SeverityLevel;
+        actualMetric: string;
+        actualValue: number;
+      };
+
+    if (!analysisId || !criterionId || predictedSeverity == null || actualValue == null) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    const accuracy = calculateAccuracy(predictedSeverity, criterionId, actualValue);
+    const deviation = calculateDeviation(predictedSeverity, criterionId, actualValue);
+
+    const record = await prisma.calibrationRecord.create({
+      data: {
+        analysisId,
+        criterionId,
+        predictedSeverity,
+        actualMetric,
+        actualValue,
+        accuracy,
+        deviation,
+      },
+    });
+
+    return NextResponse.json(record, { status: 201 });
+  } catch (error) {
+    console.error("[calibration POST]", error);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/app/api/competitors/[id]/analyze/route.ts
+++ b/app/api/competitors/[id]/analyze/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildCompetitorSystemPrompt } from "@/lib/prompts/competitor";
+import { parseFrameworkResponse } from "@/lib/frameworks";
+import { validateFrameworkIds } from "@/lib/prompts/heuristic";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+// POST /api/competitors/[id]/analyze
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { screenshots, frameworks: rawFrameworks } = await req.json();
+
+    if (!Array.isArray(screenshots) || screenshots.length === 0) {
+      return NextResponse.json({ error: "screenshots required" }, { status: 400 });
+    }
+
+    const competitor = await prisma.competitor.findUniqueOrThrow({
+      where: { id: params.id },
+    });
+
+    const frameworkIds = validateFrameworkIds(rawFrameworks);
+    const systemPrompt = buildCompetitorSystemPrompt(competitor.name);
+
+    // Build image content blocks
+    const imageBlocks: Anthropic.ImageBlockParam[] = screenshots
+      .slice(0, 8)
+      .map((img: string) => {
+        const base64 = img.replace(/^data:image\/\w+;base64,/, "");
+        return {
+          type: "image" as const,
+          source: {
+            type: "base64" as const,
+            media_type: "image/png" as const,
+            data: base64,
+          },
+        };
+      });
+
+    const frameworkInstructions =
+      frameworkIds.length > 0
+        ? `\n\n평가할 프레임워크 ID: ${frameworkIds.join(", ")}\n각 프레임워크를 {"frameworkResults": [...]} 형식으로 JSON 응답에 포함하세요.`
+        : "";
+
+    const response = await anthropic.messages.create({
+      model: MODELS.sonnet,
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages: [
+        {
+          role: "user",
+          content: [
+            ...imageBlocks,
+            {
+              type: "text",
+              text: `경쟁사 "${competitor.name}"의 스크린샷을 분석해주세요.${frameworkInstructions}\n\n결과를 JSON 형식으로 반환하세요:
+{
+  "verdict": "Pass|Partial|Fail",
+  "score": 0-100,
+  "summary": "...",
+  "strengths": ["..."],
+  "weaknesses": ["..."],
+  "benchmarkOpportunities": ["..."],
+  "issues": [{"screen": "...", "severity": "Critical|Medium|Low", "issue": "...", "recommendation": "..."}],
+  "frameworkResults": [...]
+}`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const rawText =
+      response.content[0].type === "text" ? response.content[0].text : "";
+    let parsed: Record<string, unknown> = {};
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) parsed = JSON.parse(jsonMatch[0]);
+    } catch {
+      parsed = { summary: rawText };
+    }
+
+    const frameworkResults =
+      frameworkIds.length > 0
+        ? parseFrameworkResponse(rawText, frameworkIds)
+        : [];
+
+    const analysis = await prisma.competitorAnalysis.create({
+      data: {
+        competitorId: params.id,
+        screenshots,
+        frameworks: frameworkIds,
+        results: { ...parsed, frameworkResults } as object,
+      },
+    });
+
+    return NextResponse.json({
+      id: analysis.id,
+      competitorId: params.id,
+      competitorName: competitor.name,
+      results: analysis.results,
+      createdAt: analysis.createdAt,
+    });
+  } catch (error) {
+    console.error("[competitor analyze]", error);
+    return NextResponse.json({ error: "Analysis failed" }, { status: 500 });
+  }
+}

--- a/app/api/competitors/[id]/reviews/route.ts
+++ b/app/api/competitors/[id]/reviews/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildReviewAnalysisPrompt } from "@/lib/prompts/review-analysis";
+import { parseReviewCSV } from "@/lib/store-research";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+// POST /api/competitors/[id]/reviews — upload review CSV and analyze
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { csvText, platform = "android" } = await req.json();
+
+    if (!csvText) {
+      return NextResponse.json({ error: "csvText required" }, { status: 400 });
+    }
+
+    const competitor = await prisma.competitor.findUniqueOrThrow({
+      where: { id: params.id },
+    });
+
+    const reviews = parseReviewCSV(csvText);
+    if (reviews.length === 0) {
+      return NextResponse.json({ error: "No reviews parsed" }, { status: 400 });
+    }
+
+    const prompt = buildReviewAnalysisPrompt(competitor.name, reviews);
+
+    const response = await anthropic.messages.create({
+      model: MODELS.sonnet,
+      max_tokens: 3000,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const rawText =
+      response.content[0].type === "text" ? response.content[0].text : "";
+    let analysisResult: Record<string, unknown> = {};
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) analysisResult = JSON.parse(jsonMatch[0]);
+    } catch {
+      analysisResult = { raw: rawText };
+    }
+
+    const snapshot = await prisma.storeSnapshot.create({
+      data: {
+        competitorId: params.id,
+        platform,
+        rating: reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length,
+        ratingCount: reviews.length,
+        reviews: reviews as unknown as object[],
+        updateNotes: [],
+        analysisResult: analysisResult as object,
+      },
+    });
+
+    return NextResponse.json({
+      id: snapshot.id,
+      reviewCount: reviews.length,
+      analysisResult,
+    });
+  } catch (error) {
+    console.error("[competitor reviews]", error);
+    return NextResponse.json({ error: "Review analysis failed" }, { status: 500 });
+  }
+}

--- a/app/api/competitors/[id]/route.ts
+++ b/app/api/competitors/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+// DELETE /api/competitors/[id]
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    await prisma.competitor.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}
+
+// GET /api/competitors/[id]
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const competitor = await prisma.competitor.findUniqueOrThrow({
+      where: { id: params.id },
+      include: { analyses: { orderBy: { createdAt: "desc" } } },
+    });
+    return NextResponse.json(competitor);
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/app/api/competitors/compare/route.ts
+++ b/app/api/competitors/compare/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildCompetitorComparePrompt } from "@/lib/prompts/competitor";
+import type { FrameworkResult } from "@/lib/frameworks";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+// GET /api/competitors/compare?ids=id1,id2&ourAnalysisId=xxx
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const ids = searchParams.get("ids")?.split(",").filter(Boolean) ?? [];
+    const ourAnalysisId = searchParams.get("ourAnalysisId");
+
+    if (ids.length === 0) {
+      return NextResponse.json({ error: "ids required" }, { status: 400 });
+    }
+
+    const competitorAnalyses = await prisma.competitorAnalysis.findMany({
+      where: { id: { in: ids } },
+      include: { competitor: true },
+    });
+
+    if (competitorAnalyses.length === 0) {
+      return NextResponse.json({ error: "No analyses found" }, { status: 404 });
+    }
+
+    let ourFrameworkResults: FrameworkResult[] = [];
+    if (ourAnalysisId) {
+      const ourAnalysis = await prisma.analysis.findUnique({
+        where: { id: ourAnalysisId },
+      });
+      if (ourAnalysis?.analysisOptions) {
+        const opts = ourAnalysis.analysisOptions as { result?: { frameworkResults?: FrameworkResult[] } };
+        ourFrameworkResults = opts.result?.frameworkResults ?? [];
+      }
+    }
+
+    const comparisons = await Promise.all(
+      competitorAnalyses.map(async (ca) => {
+        const compResults = (ca.results as { frameworkResults?: FrameworkResult[] })?.frameworkResults ?? [];
+
+        if (ourFrameworkResults.length === 0 || compResults.length === 0) {
+          return {
+            competitorId: ca.competitorId,
+            competitorName: ca.competitor.name,
+            analysisId: ca.id,
+            results: ca.results,
+            comparison: null,
+          };
+        }
+
+        const prompt = buildCompetitorComparePrompt(
+          ourFrameworkResults,
+          compResults,
+          ca.competitor.name
+        );
+
+        const response = await anthropic.messages.create({
+          model: MODELS.haiku,
+          max_tokens: 2048,
+          messages: [{ role: "user", content: prompt }],
+        });
+
+        let comparison: Record<string, unknown> = {};
+        const rawText =
+          response.content[0].type === "text" ? response.content[0].text : "";
+        try {
+          const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+          if (jsonMatch) comparison = JSON.parse(jsonMatch[0]);
+        } catch {
+          comparison = {};
+        }
+
+        return {
+          competitorId: ca.competitorId,
+          competitorName: ca.competitor.name,
+          analysisId: ca.id,
+          results: ca.results,
+          comparison,
+        };
+      })
+    );
+
+    return NextResponse.json({ comparisons });
+  } catch (error) {
+    console.error("[competitors compare]", error);
+    return NextResponse.json({ error: "Compare failed" }, { status: 500 });
+  }
+}

--- a/app/api/competitors/quick-analyze/route.ts
+++ b/app/api/competitors/quick-analyze/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildCompetitorSystemPrompt } from "@/lib/prompts/competitor";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+export async function POST(req: NextRequest) {
+  try {
+    const { competitorName, screenshots, frameworks = [] } = (await req.json()) as {
+      competitorName: string;
+      screenshots: string[]; // base64 images (can include video frames)
+      frameworks?: string[];
+    };
+
+    void frameworks; // reserved for future use
+
+    if (!competitorName || !screenshots || screenshots.length === 0) {
+      return NextResponse.json(
+        { error: "competitorName and screenshots required" },
+        { status: 400 }
+      );
+    }
+
+    const systemPrompt = buildCompetitorSystemPrompt(competitorName);
+
+    const imageBlocks: Anthropic.ImageBlockParam[] = screenshots
+      .slice(0, 10)
+      .map((img: string) => {
+        const base64 = img.replace(/^data:image\/\w+;base64,/, "");
+        return {
+          type: "image" as const,
+          source: { type: "base64" as const, media_type: "image/png" as const, data: base64 },
+        };
+      });
+
+    const response = await anthropic.messages.create({
+      model: MODELS.sonnet,
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages: [
+        {
+          role: "user",
+          content: [
+            ...imageBlocks,
+            {
+              type: "text",
+              text: `경쟁사 "${competitorName}"의 스크린샷 ${screenshots.length}장을 분석해주세요.
+
+결과를 JSON 형식으로 반환하세요:
+{
+  "verdict": "Pass|Partial|Fail",
+  "score": 0-100,
+  "summary": "전체 평가 요약",
+  "strengths": ["강점1", "강점2"],
+  "weaknesses": ["약점1", "약점2"],
+  "benchmarkOpportunities": ["야핏무브가 배울 점1", "배울 점2"],
+  "issues": [
+    {"screen": "화면명", "severity": "Critical|Medium|Low", "issue": "발견된 문제", "recommendation": "개선 제안"}
+  ],
+  "vsYafit": {
+    "theyWinAt": ["경쟁사가 우세한 점"],
+    "yafitWinsAt": ["야핏무브가 우세한 점"],
+    "copyThis": ["즉시 벤치마킹 가능한 요소"]
+  }
+}`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const rawText = response.content[0].type === "text" ? response.content[0].text : "";
+    let result: Record<string, unknown> = {};
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) result = JSON.parse(jsonMatch[0]);
+    } catch {
+      result = { summary: rawText };
+    }
+
+    return NextResponse.json({
+      competitorName,
+      screenshotCount: screenshots.length,
+      result,
+    });
+  } catch (error) {
+    console.error("[quick-analyze]", error);
+    return NextResponse.json({ error: "Analysis failed" }, { status: 500 });
+  }
+}

--- a/app/api/competitors/route.ts
+++ b/app/api/competitors/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+// GET /api/competitors — list all competitors
+export async function GET() {
+  try {
+    const competitors = await prisma.competitor.findMany({
+      include: {
+        analyses: { orderBy: { createdAt: "desc" }, take: 1 },
+        _count: { select: { analyses: true, snapshots: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    return NextResponse.json(competitors);
+  } catch (error) {
+    console.error("[competitors GET]", error);
+    return NextResponse.json({ error: "Failed to fetch competitors" }, { status: 500 });
+  }
+}
+
+// POST /api/competitors — register a competitor
+export async function POST(req: NextRequest) {
+  try {
+    const { name, url, logoUrl } = await req.json();
+    if (!name) return NextResponse.json({ error: "name required" }, { status: 400 });
+
+    const competitor = await prisma.competitor.create({
+      data: { name, url: url ?? null, logoUrl: logoUrl ?? null },
+    });
+    return NextResponse.json(competitor, { status: 201 });
+  } catch (error) {
+    console.error("[competitors POST]", error);
+    return NextResponse.json({ error: "Failed to create competitor" }, { status: 500 });
+  }
+}

--- a/app/api/settings/slack/route.ts
+++ b/app/api/settings/slack/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+export async function GET() {
+  try {
+    const config = await prisma.slackConfig.findFirst({ where: { isActive: true } });
+    return NextResponse.json(config ?? null);
+  } catch {
+    return NextResponse.json(null);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { webhookUrl } = (await req.json()) as { webhookUrl: string };
+    if (!webhookUrl) return NextResponse.json({ error: "webhookUrl required" }, { status: 400 });
+
+    // Deactivate existing configs
+    await prisma.slackConfig.updateMany({ where: {}, data: { isActive: false } });
+
+    const config = await prisma.slackConfig.create({ data: { webhookUrl } });
+    return NextResponse.json(config, { status: 201 });
+  } catch (error) {
+    console.error("[slack POST]", error);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/app/api/simulate/economy/route.ts
+++ b/app/api/simulate/economy/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import {
+  buildEconomySimPrompt,
+  type EconomyVariables,
+} from "@/lib/prompts/economy-sim";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const { currentVars, proposedVars } = (await req.json()) as {
+      currentVars: EconomyVariables;
+      proposedVars: EconomyVariables;
+    };
+
+    if (!currentVars || !proposedVars) {
+      return NextResponse.json(
+        { error: "currentVars and proposedVars required" },
+        { status: 400 }
+      );
+    }
+
+    const prompt = buildEconomySimPrompt(currentVars, proposedVars);
+
+    const response = await anthropic.messages.create({
+      model: MODELS.sonnet,
+      max_tokens: 2500,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const rawText =
+      response.content[0].type === "text" ? response.content[0].text : "";
+    let result: Record<string, unknown> = {};
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) result = JSON.parse(jsonMatch[0]);
+    } catch {
+      result = { raw: rawText };
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[economy simulate]", error);
+    return NextResponse.json(
+      { error: "Economy simulation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/simulate/route.ts
+++ b/app/api/simulate/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildSimulationPrompt } from "@/lib/prompts/simulation";
+import type { FrameworkResult } from "@/lib/frameworks";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const { originalResults, hypothesis, changeDescription, affectedScreens } =
+      (await req.json()) as {
+        originalResults: FrameworkResult[];
+        hypothesis: string;
+        changeDescription: string;
+        affectedScreens?: string[];
+      };
+
+    if (!hypothesis || !changeDescription || !Array.isArray(originalResults)) {
+      return NextResponse.json(
+        { error: "hypothesis, changeDescription, originalResults required" },
+        { status: 400 }
+      );
+    }
+
+    const prompt = buildSimulationPrompt(originalResults, hypothesis, changeDescription);
+
+    const response = await anthropic.messages.create({
+      model: MODELS.sonnet,
+      max_tokens: 3000,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const rawText =
+      response.content[0].type === "text" ? response.content[0].text : "";
+    let result: Record<string, unknown> = {};
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) result = JSON.parse(jsonMatch[0]);
+    } catch {
+      result = { raw: rawText };
+    }
+
+    return NextResponse.json({
+      before: originalResults,
+      after: result.afterResults ?? [],
+      delta: result.deltas ?? [],
+      abTestWorth: result.abTestWorth ?? false,
+      abTestRationale: result.abTestRationale ?? "",
+      estimatedImpact: result.estimatedImpact ?? {},
+      affectedScreens,
+    });
+  } catch (error) {
+    console.error("[simulate]", error);
+    return NextResponse.json({ error: "Simulation failed" }, { status: 500 });
+  }
+}

--- a/app/api/ux-writing/route.ts
+++ b/app/api/ux-writing/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
+import { buildUXWritingPrompt } from "@/lib/prompts/ux-writing";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const {
+      issueContext,
+      currentCopy,
+      screenContext,
+      tones,
+    } = (await req.json()) as {
+      issueContext: string;
+      currentCopy?: string;
+      screenContext: string;
+      tones: string[];
+      language?: string;
+    };
+
+    if (
+      !issueContext ||
+      !screenContext ||
+      !Array.isArray(tones) ||
+      tones.length === 0
+    ) {
+      return NextResponse.json(
+        { error: "issueContext, screenContext, tones required" },
+        { status: 400 }
+      );
+    }
+
+    const prompt = buildUXWritingPrompt(
+      issueContext,
+      currentCopy,
+      screenContext,
+      tones
+    );
+
+    const response = await anthropic.messages.create({
+      model: MODELS.haiku,
+      max_tokens: 2000,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const rawText =
+      response.content[0].type === "text" ? response.content[0].text : "";
+    let result: { variants?: unknown[] } = { variants: [] };
+    try {
+      const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+      if (jsonMatch) result = JSON.parse(jsonMatch[0]);
+    } catch {
+      result = { variants: [] };
+    }
+
+    return NextResponse.json({ variants: result.variants ?? [] });
+  } catch (error) {
+    console.error("[ux-writing]", error);
+    return NextResponse.json(
+      { error: "UX writing generation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/competitor/page.tsx
+++ b/app/competitor/page.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useState } from "react";
+import { MediaUploader, type UploadedVideo } from "@/components/MediaUploader";
+
+interface QuickAnalysisResult {
+  verdict?: "Pass" | "Partial" | "Fail";
+  score?: number;
+  summary?: string;
+  strengths?: string[];
+  weaknesses?: string[];
+  benchmarkOpportunities?: string[];
+  issues?: { screen: string; severity: string; issue: string; recommendation: string }[];
+  vsYafit?: {
+    theyWinAt?: string[];
+    yafitWinsAt?: string[];
+    copyThis?: string[];
+  };
+}
+
+export default function CompetitorAnalyzePage() {
+  const [name, setName] = useState("");
+  const [images, setImages] = useState<string[]>([]);
+  const [videos, setVideos] = useState<UploadedVideo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<QuickAnalysisResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const videoFrames = videos.flatMap((v) => v.frames.map((f) => f.base64));
+  const allImages = [...images, ...videoFrames];
+  const canAnalyze = name.trim().length > 0 && allImages.length > 0;
+
+  async function analyze() {
+    if (!canAnalyze) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/competitors/quick-analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          competitorName: name.trim(),
+          screenshots: allImages,
+        }),
+      });
+      if (!res.ok) throw new Error("분석 실패");
+      const data = await res.json();
+      setResult(data.result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "오류 발생");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveAsCompetitor() {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      await fetch("/api/competitors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim() }),
+      });
+      setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const verdictColor: Record<string, string> = {
+    Pass: "text-green-400 bg-green-900/30 border-green-800",
+    Partial: "text-yellow-400 bg-yellow-900/30 border-yellow-800",
+    Fail: "text-red-400 bg-red-900/30 border-red-800",
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a]">
+      <div className="max-w-3xl mx-auto p-6 space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold text-white">경쟁사 독립 분석</h1>
+          <p className="text-gray-400 mt-1 text-sm">
+            경쟁사 앱의 스크린샷 또는 영상을 업로드하여 야핏무브와 동일한 기준으로 분석합니다.
+          </p>
+        </div>
+
+        {/* Input form */}
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-4">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1.5">경쟁사 이름</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 머니워크, 돈이돼지, Sweatcoin"
+              className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1.5">
+              스크린샷 / 영상 업로드
+            </label>
+            <MediaUploader
+              images={images}
+              videos={videos}
+              onImagesChange={setImages}
+              onVideosChange={setVideos}
+              maxImages={10}
+              maxVideos={2}
+              uploadZoneId="competitor-analyze"
+              showError={false}
+            />
+          </div>
+
+          {allImages.length > 0 && (
+            <p className="text-xs text-gray-500">
+              총 {allImages.length}장 준비됨
+              {videoFrames.length > 0 &&
+                ` (이미지 ${images.length}장 + 영상 프레임 ${videoFrames.length}장)`}
+            </p>
+          )}
+
+          <button
+            onClick={analyze}
+            disabled={!canAnalyze || loading}
+            className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded transition-colors"
+          >
+            {loading ? "분석 중..." : "분석 시작"}
+          </button>
+        </div>
+
+        {error && (
+          <div className="bg-red-900/20 border border-red-800 rounded-lg p-4 text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Results */}
+        {result && (
+          <div className="space-y-4">
+            {/* Verdict + score */}
+            <div className="flex items-center gap-4">
+              {result.verdict && (
+                <span
+                  className={`text-sm px-3 py-1 rounded border font-medium ${
+                    verdictColor[result.verdict] ?? "text-gray-400"
+                  }`}
+                >
+                  {result.verdict}
+                </span>
+              )}
+              {result.score != null && (
+                <span className="text-2xl font-bold font-mono text-white">
+                  {result.score}
+                  <span className="text-sm text-gray-500">/100</span>
+                </span>
+              )}
+              {!saved && (
+                <button
+                  onClick={saveAsCompetitor}
+                  disabled={saving}
+                  className="ml-auto text-xs px-3 py-1.5 border border-gray-600 hover:border-gray-400 text-gray-300 rounded transition-colors"
+                >
+                  {saving ? "저장중..." : "경쟁사로 등록"}
+                </button>
+              )}
+              {saved && (
+                <span className="ml-auto text-xs text-green-400">경쟁사 등록됨</span>
+              )}
+            </div>
+
+            {/* Summary */}
+            {result.summary && (
+              <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                <div className="text-xs text-gray-400 mb-1">요약</div>
+                <p className="text-sm text-gray-200">{result.summary}</p>
+              </div>
+            )}
+
+            {/* vs Yafit */}
+            {result.vsYafit && (
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                {result.vsYafit.theyWinAt && result.vsYafit.theyWinAt.length > 0 && (
+                  <div className="bg-red-900/20 border border-red-900 rounded-lg p-4">
+                    <div className="text-xs text-red-400 mb-2">경쟁사 우세</div>
+                    <ul className="space-y-1">
+                      {result.vsYafit.theyWinAt.map((item, i) => (
+                        <li key={i} className="text-xs text-red-300">
+                          • {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {result.vsYafit.yafitWinsAt && result.vsYafit.yafitWinsAt.length > 0 && (
+                  <div className="bg-green-900/20 border border-green-900 rounded-lg p-4">
+                    <div className="text-xs text-green-400 mb-2">야핏무브 우세</div>
+                    <ul className="space-y-1">
+                      {result.vsYafit.yafitWinsAt.map((item, i) => (
+                        <li key={i} className="text-xs text-green-300">
+                          • {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {result.vsYafit.copyThis && result.vsYafit.copyThis.length > 0 && (
+                  <div className="bg-blue-900/20 border border-blue-900 rounded-lg p-4">
+                    <div className="text-xs text-blue-400 mb-2">벤치마킹 포인트</div>
+                    <ul className="space-y-1">
+                      {result.vsYafit.copyThis.map((item, i) => (
+                        <li key={i} className="text-xs text-blue-300">
+                          • {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Strengths & Weaknesses */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {result.strengths && result.strengths.length > 0 && (
+                <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                  <div className="text-xs text-gray-400 mb-2">강점</div>
+                  <ul className="space-y-1">
+                    {result.strengths.map((s, i) => (
+                      <li key={i} className="text-xs text-gray-300">
+                        • {s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {result.weaknesses && result.weaknesses.length > 0 && (
+                <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                  <div className="text-xs text-gray-400 mb-2">약점</div>
+                  <ul className="space-y-1">
+                    {result.weaknesses.map((w, i) => (
+                      <li key={i} className="text-xs text-gray-300">
+                        • {w}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+
+            {/* Benchmark opportunities */}
+            {result.benchmarkOpportunities && result.benchmarkOpportunities.length > 0 && (
+              <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                <div className="text-xs text-gray-400 mb-2">야핏무브가 배울 점</div>
+                <ul className="space-y-1">
+                  {result.benchmarkOpportunities.map((o, i) => (
+                    <li key={i} className="text-xs text-gray-300">
+                      • {o}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Issues */}
+            {result.issues && result.issues.length > 0 && (
+              <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                <div className="text-xs text-gray-400 mb-3">발견된 이슈</div>
+                <div className="space-y-3">
+                  {result.issues.map((issue, i) => (
+                    <div key={i} className="border-l-2 border-gray-700 pl-3">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span
+                          className={`text-xs px-1.5 py-0.5 rounded ${
+                            issue.severity === "Critical"
+                              ? "bg-red-900 text-red-300"
+                              : issue.severity === "Medium"
+                              ? "bg-yellow-900 text-yellow-300"
+                              : "bg-gray-800 text-gray-400"
+                          }`}
+                        >
+                          {issue.severity}
+                        </span>
+                        <span className="text-xs text-gray-500">{issue.screen}</span>
+                      </div>
+                      <p className="text-xs text-gray-300">{issue.issue}</p>
+                      <p className="text-xs text-blue-400 mt-1">→ {issue.recommendation}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/competitive/page.tsx
+++ b/app/dashboard/competitive/page.tsx
@@ -1,0 +1,19 @@
+import CompetitiveDashboard from "@/components/CompetitiveDashboard";
+
+export const metadata = { title: "경쟁 인텔리전스 | Simulo" };
+
+export default function CompetitivePage() {
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-6">
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-white">경쟁 인텔리전스</h1>
+          <p className="text-gray-400 mt-1 text-sm">
+            경쟁사 앱을 야핏무브와 동일한 기준으로 분석하고 격차를 추적합니다.
+          </p>
+        </div>
+        <CompetitiveDashboard />
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/impact/page.tsx
+++ b/app/dashboard/impact/page.tsx
@@ -1,0 +1,215 @@
+import { prisma } from "@/lib/db";
+import { analyzeCalibrationTrend } from "@/lib/prompt-calibration";
+import type { CalibrationRecord, SeverityLevel } from "@/lib/calibration";
+
+export const metadata = { title: "개선 효과 추적 | Simulo" };
+
+async function getCalibrationData() {
+  const rawRecords = await prisma.calibrationRecord.findMany({
+    orderBy: { calibratedAt: "desc" },
+    take: 500,
+  });
+
+  const records: CalibrationRecord[] = rawRecords.map((r) => ({
+    id: r.id,
+    analysisId: r.analysisId,
+    criterionId: r.criterionId,
+    predictedSeverity: r.predictedSeverity as SeverityLevel,
+    actualMetric: r.actualMetric,
+    actualValue: r.actualValue,
+    accuracy: r.accuracy as CalibrationRecord["accuracy"],
+    deviation: r.deviation,
+    calibratedAt: r.calibratedAt,
+  }));
+
+  const adjustments = analyzeCalibrationTrend(records);
+  const totalRecords = records.length;
+  const accurateCount = records.filter((r) => r.accuracy === "accurate").length;
+  const overCount = records.filter((r) => r.accuracy === "overestimated").length;
+  const underCount = records.filter((r) => r.accuracy === "underestimated").length;
+
+  return {
+    records: records.slice(0, 20),
+    adjustments,
+    stats: {
+      total: totalRecords,
+      accurate: accurateCount,
+      overestimated: overCount,
+      underestimated: underCount,
+      accuracyRate: totalRecords > 0 ? Math.round((accurateCount / totalRecords) * 100) : null,
+    },
+  };
+}
+
+export default async function ImpactPage() {
+  const { records, adjustments, stats } = await getCalibrationData();
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-6">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-white">개선 효과 추적</h1>
+          <p className="text-gray-400 mt-1 text-sm">
+            AI 예측과 실측 데이터를 비교하여 분석 정확도를 개선합니다.
+          </p>
+        </div>
+
+        {/* Stats overview */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[
+            { label: "총 캘리브레이션", value: stats.total, color: "text-white" },
+            {
+              label: "정확 예측",
+              value: stats.accurate,
+              color: "text-green-400",
+            },
+            {
+              label: "과대 평가",
+              value: stats.overestimated,
+              color: "text-yellow-400",
+            },
+            {
+              label: "과소 평가",
+              value: stats.underestimated,
+              color: "text-red-400",
+            },
+          ].map((s) => (
+            <div
+              key={s.label}
+              className="bg-gray-900 border border-gray-700 rounded-lg p-4"
+            >
+              <div className={`text-2xl font-bold font-mono ${s.color}`}>{s.value}</div>
+              <div className="text-xs text-gray-500 mt-1">{s.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Accuracy rate */}
+        {stats.accuracyRate !== null && (
+          <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-gray-300">예측 정확도</span>
+              <span
+                className={`text-sm font-mono font-bold ${
+                  stats.accuracyRate >= 70
+                    ? "text-green-400"
+                    : stats.accuracyRate >= 50
+                    ? "text-yellow-400"
+                    : "text-red-400"
+                }`}
+              >
+                {stats.accuracyRate}%
+              </span>
+            </div>
+            <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  stats.accuracyRate >= 70
+                    ? "bg-green-500"
+                    : stats.accuracyRate >= 50
+                    ? "bg-yellow-500"
+                    : "bg-red-500"
+                }`}
+                style={{ width: `${stats.accuracyRate}%` }}
+              />
+            </div>
+            <div className="text-xs text-gray-500 mt-1">목표: 70% 이상</div>
+          </div>
+        )}
+
+        {/* Active calibration adjustments */}
+        {adjustments.length > 0 && (
+          <div>
+            <h2 className="text-sm font-semibold text-white mb-3">
+              활성 보정 ({adjustments.length}건)
+            </h2>
+            <div className="space-y-2">
+              {adjustments.map((adj) => (
+                <div
+                  key={adj.criterionId}
+                  className="bg-gray-900 border border-gray-700 rounded-lg p-4 flex items-start gap-4"
+                >
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded font-mono ${
+                      adj.direction === "lower"
+                        ? "bg-yellow-900 text-yellow-300"
+                        : "bg-blue-900 text-blue-300"
+                    }`}
+                  >
+                    {adj.direction === "lower" ? "↓ 완화" : "↑ 강화"}
+                  </span>
+                  <div className="flex-1">
+                    <div className="text-sm text-gray-200 font-mono">{adj.criterionId}</div>
+                    <div className="text-xs text-gray-500 mt-0.5">
+                      {adj.sampleSize}건 기반 · 강도: {adj.magnitude} · 정확도:{" "}
+                      {Math.round(adj.accuracyRate * 100)}%
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Recent calibration records */}
+        {records.length > 0 && (
+          <div>
+            <h2 className="text-sm font-semibold text-white mb-3">최근 캘리브레이션</h2>
+            <div className="bg-gray-900 border border-gray-700 rounded-lg overflow-hidden">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-gray-700">
+                    <th className="text-left p-3 text-gray-500 font-normal">기준</th>
+                    <th className="text-left p-3 text-gray-500 font-normal">예측 심각도</th>
+                    <th className="text-left p-3 text-gray-500 font-normal">실측값</th>
+                    <th className="text-left p-3 text-gray-500 font-normal">정확도</th>
+                    <th className="text-left p-3 text-gray-500 font-normal">날짜</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {records.map((r) => (
+                    <tr key={r.id} className="border-b border-gray-800 hover:bg-gray-800/50">
+                      <td className="p-3 font-mono text-gray-300">{r.criterionId}</td>
+                      <td className="p-3 text-gray-300">{r.predictedSeverity}/4</td>
+                      <td className="p-3 text-gray-300">{(r.actualValue * 100).toFixed(1)}%</td>
+                      <td className="p-3">
+                        <span
+                          className={`px-1.5 py-0.5 rounded ${
+                            r.accuracy === "accurate"
+                              ? "bg-green-900 text-green-300"
+                              : r.accuracy === "overestimated"
+                              ? "bg-yellow-900 text-yellow-300"
+                              : "bg-red-900 text-red-300"
+                          }`}
+                        >
+                          {r.accuracy === "accurate"
+                            ? "정확"
+                            : r.accuracy === "overestimated"
+                            ? "과대"
+                            : "과소"}
+                        </span>
+                      </td>
+                      <td className="p-3 text-gray-500">
+                        {new Date(r.calibratedAt).toLocaleDateString("ko-KR")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {records.length === 0 && (
+          <div className="text-center text-gray-500 py-16">
+            <div className="text-4xl mb-3">📊</div>
+            <div className="text-sm">아직 캘리브레이션 데이터가 없습니다.</div>
+            <div className="text-xs text-gray-600 mt-1">
+              분석 결과와 실측 데이터를 연결하면 여기에 표시됩니다.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/economy/page.tsx
+++ b/app/economy/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState } from "react";
+import type { EconomyVariables } from "@/lib/prompts/economy-sim";
+
+const DEFAULT_VARS: EconomyVariables = {
+  pointsPerStep: 100,
+  exchangeThreshold: 5000,
+  dailyAdSlots: 5,
+  streakBonusMultiplier: 1.5,
+  adRewardPoints: 100,
+  pointExpiryDays: 90,
+};
+
+interface SimResult {
+  retentionImpact?: { d1: string; d7: string; d30: string };
+  arpdauImpact?: string;
+  exchangeRateImpact?: string;
+  competitivePosition?: string;
+  risks?: string[];
+  recommendation?: string;
+}
+
+const VARIABLE_LABELS: {
+  key: keyof EconomyVariables;
+  label: string;
+  unit: string;
+  min: number;
+  max: number;
+  step: number;
+}[] = [
+  {
+    key: "pointsPerStep",
+    label: "걸음당 포인트",
+    unit: "p/1만보",
+    min: 50,
+    max: 500,
+    step: 10,
+  },
+  {
+    key: "exchangeThreshold",
+    label: "최소 교환 금액",
+    unit: "원",
+    min: 1000,
+    max: 20000,
+    step: 500,
+  },
+  {
+    key: "dailyAdSlots",
+    label: "일일 광고 슬롯",
+    unit: "개",
+    min: 1,
+    max: 20,
+    step: 1,
+  },
+  {
+    key: "streakBonusMultiplier",
+    label: "스트릭 보너스 배율",
+    unit: "x",
+    min: 1,
+    max: 5,
+    step: 0.1,
+  },
+  {
+    key: "adRewardPoints",
+    label: "광고 1회 보상",
+    unit: "포인트",
+    min: 10,
+    max: 500,
+    step: 10,
+  },
+  {
+    key: "pointExpiryDays",
+    label: "포인트 만료",
+    unit: "일",
+    min: 30,
+    max: 365,
+    step: 30,
+  },
+];
+
+export default function EconomyPage() {
+  const [current] = useState<EconomyVariables>(DEFAULT_VARS);
+  const [proposed, setProposed] = useState<EconomyVariables>({
+    ...DEFAULT_VARS,
+  });
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<SimResult | null>(null);
+
+  async function runSim() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/simulate/economy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentVars: current, proposedVars: proposed }),
+      });
+      const data = await res.json();
+      setResult(data);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function updateVar(key: keyof EconomyVariables, value: number) {
+    setProposed((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-6">
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-white">
+            리워드 이코노미 시뮬레이터
+          </h1>
+          <p className="text-gray-400 mt-1 text-sm">
+            포인트 경제 변수를 조절하여 리텐션·ARPDAU에 미치는 영향을
+            시뮬레이션합니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Sliders */}
+          <div className="space-y-4">
+            <h2 className="text-sm font-semibold text-white">변수 설정</h2>
+            {VARIABLE_LABELS.map(({ key, label, unit, min, max, step }) => (
+              <div
+                key={key}
+                className="bg-gray-900 border border-gray-700 rounded-lg p-4"
+              >
+                <div className="flex justify-between items-center mb-2">
+                  <span className="text-sm text-gray-300">{label}</span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-gray-500 line-through">
+                      {current[key]}
+                    </span>
+                    <span className="text-sm font-mono text-white">
+                      {proposed[key]} {unit}
+                    </span>
+                  </div>
+                </div>
+                <input
+                  type="range"
+                  min={min}
+                  max={max}
+                  step={step}
+                  value={proposed[key]}
+                  onChange={(e) => updateVar(key, Number(e.target.value))}
+                  className="w-full accent-blue-500"
+                />
+                <div className="flex justify-between text-xs text-gray-600 mt-1">
+                  <span>{min}</span>
+                  <span>{max}</span>
+                </div>
+              </div>
+            ))}
+            <button
+              onClick={runSim}
+              disabled={loading}
+              className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded transition-colors"
+            >
+              {loading ? "시뮬레이션 중..." : "시뮬레이션 실행"}
+            </button>
+          </div>
+
+          {/* Results */}
+          <div className="space-y-4">
+            <h2 className="text-sm font-semibold text-white">
+              시뮬레이션 결과
+            </h2>
+            {!result ? (
+              <div className="bg-gray-900 border border-gray-700 rounded-lg p-8 text-center text-gray-500 text-sm">
+                변수를 설정하고 시뮬레이션을 실행하세요
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {/* Retention */}
+                {result.retentionImpact && (
+                  <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                    <div className="text-xs text-gray-400 mb-2">
+                      리텐션 변화
+                    </div>
+                    <div className="grid grid-cols-3 gap-3">
+                      {(["d1", "d7", "d30"] as const).map((k) => (
+                        <div key={k} className="text-center">
+                          <div className="text-xs text-gray-500">
+                            {k.toUpperCase()}
+                          </div>
+                          <div
+                            className={`text-sm font-mono font-bold ${
+                              (result.retentionImpact![k] ?? "").startsWith("+")
+                                ? "text-green-400"
+                                : "text-red-400"
+                            }`}
+                          >
+                            {result.retentionImpact![k]}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* ARPDAU */}
+                {result.arpdauImpact && (
+                  <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                    <div className="text-xs text-gray-400 mb-1">
+                      ARPDAU 영향
+                    </div>
+                    <div className="text-sm text-gray-200">
+                      {result.arpdauImpact}
+                    </div>
+                  </div>
+                )}
+
+                {/* Exchange rate */}
+                {result.exchangeRateImpact && (
+                  <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                    <div className="text-xs text-gray-400 mb-1">교환 전환율</div>
+                    <div className="text-sm text-gray-200">
+                      {result.exchangeRateImpact}
+                    </div>
+                  </div>
+                )}
+
+                {/* Competitive position */}
+                {result.competitivePosition && (
+                  <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+                    <div className="text-xs text-gray-400 mb-1">
+                      경쟁사 대비 포지션
+                    </div>
+                    <div className="text-sm text-gray-200">
+                      {result.competitivePosition}
+                    </div>
+                  </div>
+                )}
+
+                {/* Risks */}
+                {result.risks && result.risks.length > 0 && (
+                  <div className="bg-red-900/20 border border-red-900 rounded-lg p-4">
+                    <div className="text-xs text-red-400 mb-2">리스크</div>
+                    <ul className="space-y-1">
+                      {result.risks.map((r, i) => (
+                        <li key={i} className="text-sm text-red-300">
+                          • {r}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Recommendation */}
+                {result.recommendation && (
+                  <div className="bg-blue-900/20 border border-blue-900 rounded-lg p-4">
+                    <div className="text-xs text-blue-400 mb-1">권장 사항</div>
+                    <div className="text-sm text-blue-200">
+                      {result.recommendation}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/integrations/page.tsx
+++ b/app/settings/integrations/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export default function IntegrationsPage() {
+  const [slackUrl, setSlackUrl] = useState("");
+  const [savedSlackUrl, setSavedSlackUrl] = useState<string | null>(null);
+  const [savingSlack, setSavingSlack] = useState(false);
+  const [slackSaved, setSlackSaved] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/settings/slack")
+      .then((r) => r.json())
+      .then((d: { webhookUrl?: string } | null) => {
+        if (d?.webhookUrl) setSavedSlackUrl(d.webhookUrl);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function saveSlack() {
+    if (!slackUrl.trim()) return;
+    setSavingSlack(true);
+    try {
+      await fetch("/api/settings/slack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ webhookUrl: slackUrl.trim() }),
+      });
+      setSavedSlackUrl(slackUrl.trim());
+      setSlackUrl("");
+      setSlackSaved(true);
+      setTimeout(() => setSlackSaved(false), 2000);
+    } finally {
+      setSavingSlack(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-6">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-white">통합 설정</h1>
+          <p className="text-gray-400 mt-1 text-sm">외부 서비스 연동을 설정합니다.</p>
+        </div>
+
+        {/* Slack */}
+        <section className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-purple-600 rounded flex items-center justify-center text-white text-sm font-bold">
+              S
+            </div>
+            <div>
+              <div className="font-medium text-white">Slack</div>
+              <div className="text-xs text-gray-500">
+                분석 완료·경쟁사 변화·캘리브레이션 드리프트 알림
+              </div>
+            </div>
+            {savedSlackUrl && (
+              <span className="ml-auto text-xs text-green-400 bg-green-900/30 px-2 py-0.5 rounded">
+                연결됨
+              </span>
+            )}
+          </div>
+
+          {savedSlackUrl && (
+            <div className="text-xs text-gray-500 bg-gray-800 rounded px-3 py-2 font-mono truncate">
+              {savedSlackUrl}
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <input
+              value={slackUrl}
+              onChange={(e) => setSlackUrl(e.target.value)}
+              placeholder="https://hooks.slack.com/services/..."
+              className="flex-1 bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+            />
+            <button
+              onClick={saveSlack}
+              disabled={savingSlack || !slackUrl.trim()}
+              className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 text-white text-sm rounded transition-colors"
+            >
+              {slackSaved ? "저장됨" : savingSlack ? "저장중..." : "저장"}
+            </button>
+          </div>
+        </section>
+
+        {/* GA4 — placeholder for future */}
+        <section className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-3 opacity-60">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-orange-600 rounded flex items-center justify-center text-white text-sm font-bold">
+              G
+            </div>
+            <div>
+              <div className="font-medium text-white">Google Analytics 4</div>
+              <div className="text-xs text-gray-500">
+                실측 데이터 기반 캘리브레이션 (준비 중)
+              </div>
+            </div>
+            <span className="ml-auto text-xs text-gray-500 bg-gray-800 px-2 py-0.5 rounded">
+              Coming Soon
+            </span>
+          </div>
+        </section>
+
+        {/* Jira/Linear — placeholder */}
+        <section className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-3 opacity-60">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-blue-600 rounded flex items-center justify-center text-white text-sm font-bold">
+              J
+            </div>
+            <div>
+              <div className="font-medium text-white">Jira / Linear</div>
+              <div className="text-xs text-gray-500">
+                심각도 3+ 이슈 자동 태스크 생성 (준비 중)
+              </div>
+            </div>
+            <span className="ml-auto text-xs text-gray-500 bg-gray-800 px-2 py-0.5 rounded">
+              Coming Soon
+            </span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/CompetitiveDashboard.tsx
+++ b/components/CompetitiveDashboard.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  ResponsiveContainer,
+  Legend,
+  Tooltip,
+} from "recharts";
+
+interface Competitor {
+  id: string;
+  name: string;
+  url?: string;
+  createdAt: string;
+  _count: { analyses: number; snapshots: number };
+  analyses: CompetitorAnalysis[];
+}
+
+interface CompetitorAnalysis {
+  id: string;
+  competitorId: string;
+  frameworks: string[];
+  results: AnalysisResults;
+  createdAt: string;
+}
+
+interface AnalysisResults {
+  verdict?: string;
+  score?: number;
+  summary?: string;
+  strengths?: string[];
+  weaknesses?: string[];
+  benchmarkOpportunities?: string[];
+  issues?: { screen: string; severity: string; issue: string; recommendation: string }[];
+  frameworkResults?: FrameworkResult[];
+}
+
+interface FrameworkResult {
+  frameworkId: string;
+  frameworkName: string;
+  overallScore: number;
+}
+
+export default function CompetitiveDashboard() {
+  const [competitors, setCompetitors] = useState<Competitor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedAnalyses, setSelectedAnalyses] = useState<CompetitorAnalysis[]>([]);
+  const [addingNew, setAddingNew] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+  const [uploadingFor, setUploadingFor] = useState<string | null>(null);
+  const [analyzing, setAnalyzing] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchCompetitors();
+  }, []);
+
+  async function fetchCompetitors() {
+    try {
+      const res = await fetch("/api/competitors");
+      const data = await res.json();
+      setCompetitors(Array.isArray(data) ? data : []);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function addCompetitor() {
+    if (!newName.trim()) return;
+    await fetch("/api/competitors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim(), url: newUrl.trim() || undefined }),
+    });
+    setNewName("");
+    setNewUrl("");
+    setAddingNew(false);
+    fetchCompetitors();
+  }
+
+  async function deleteCompetitor(id: string) {
+    await fetch(`/api/competitors/${id}`, { method: "DELETE" });
+    fetchCompetitors();
+  }
+
+  function handleFileUpload(competitorId: string, files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setUploadingFor(competitorId);
+    const promises = Array.from(files).slice(0, 8).map(
+      (f) =>
+        new Promise<string>((resolve) => {
+          const reader = new FileReader();
+          reader.onload = (e) => resolve(e.target?.result as string);
+          reader.readAsDataURL(f);
+        })
+    );
+    Promise.all(promises).then(async (screenshots) => {
+      setAnalyzing(competitorId);
+      setUploadingFor(null);
+      try {
+        await fetch(`/api/competitors/${competitorId}/analyze`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ screenshots, frameworks: [] }),
+        });
+        fetchCompetitors();
+      } finally {
+        setAnalyzing(null);
+      }
+    });
+  }
+
+  // Build radar chart data from selected analyses
+  const radarData: { axis: string; [key: string]: string | number }[] = [];
+  if (selectedAnalyses.length > 0) {
+    const allFrameworks = new Set<string>();
+    selectedAnalyses.forEach((a) =>
+      (a.results.frameworkResults ?? []).forEach((f) => allFrameworks.add(f.frameworkId))
+    );
+    allFrameworks.forEach((fId) => {
+      const entry: { axis: string; [key: string]: string | number } = { axis: fId };
+      selectedAnalyses.forEach((a) => {
+        const fr = (a.results.frameworkResults ?? []).find((f) => f.frameworkId === fId);
+        const comp = competitors.find((c) => c.id === a.competitorId);
+        if (comp) entry[comp.name] = fr?.overallScore ?? 0;
+      });
+      radarData.push(entry);
+    });
+  }
+
+  const COLORS = ["#60a5fa", "#f59e0b", "#34d399", "#f87171"];
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-gray-400">
+        loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">경쟁 인텔리전스</h2>
+        <button
+          onClick={() => setAddingNew(true)}
+          className="text-sm px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+        >
+          + 경쟁사 추가
+        </button>
+      </div>
+
+      {/* Add competitor form */}
+      {addingNew && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-4 space-y-3">
+          <input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="경쟁사 이름 (예: 머니워크)"
+            className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          />
+          <input
+            value={newUrl}
+            onChange={(e) => setNewUrl(e.target.value)}
+            placeholder="앱스토어 URL (선택)"
+            className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={addCompetitor}
+              className="text-sm px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded"
+            >
+              추가
+            </button>
+            <button
+              onClick={() => setAddingNew(false)}
+              className="text-sm px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white rounded"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Competitor list */}
+      {competitors.length === 0 ? (
+        <div className="text-center text-gray-500 py-12">
+          등록된 경쟁사가 없습니다. 위에서 추가하세요.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {competitors.map((c) => (
+            <div key={c.id} className="bg-gray-900 border border-gray-700 rounded-lg">
+              <div className="flex items-center justify-between p-4">
+                <div>
+                  <div className="font-medium text-white">{c.name}</div>
+                  {c.url && (
+                    <a
+                      href={c.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      {c.url}
+                    </a>
+                  )}
+                  <div className="text-xs text-gray-500 mt-1">
+                    분석 {c._count.analyses}회 · 리뷰 {c._count.snapshots}회
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {c.analyses.length > 0 && (
+                    <button
+                      onClick={() => {
+                        const analysis = c.analyses[0];
+                        setSelectedAnalyses((prev) => {
+                          const exists = prev.find((a) => a.competitorId === c.id);
+                          if (exists) return prev.filter((a) => a.competitorId !== c.id);
+                          return [...prev, analysis];
+                        });
+                      }}
+                      className={`text-xs px-2 py-1 rounded border transition-colors ${
+                        selectedAnalyses.some((a) => a.competitorId === c.id)
+                          ? "bg-blue-600 border-blue-500 text-white"
+                          : "border-gray-600 text-gray-400 hover:border-gray-400"
+                      }`}
+                    >
+                      비교
+                    </button>
+                  )}
+                  <label className={`text-xs px-2 py-1 rounded border border-gray-600 text-gray-400 hover:border-gray-400 cursor-pointer transition-colors ${analyzing === c.id ? "opacity-50" : ""}`}>
+                    {analyzing === c.id ? "분석중..." : uploadingFor === c.id ? "업로드중..." : "스크린샷 분석"}
+                    <input
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      className="hidden"
+                      disabled={!!analyzing}
+                      onChange={(e) => handleFileUpload(c.id, e.target.files)}
+                    />
+                  </label>
+                  <button
+                    onClick={() => setExpandedId(expandedId === c.id ? null : c.id)}
+                    className="text-xs px-2 py-1 rounded border border-gray-700 text-gray-400 hover:border-gray-500"
+                  >
+                    {expandedId === c.id ? "접기" : "결과"}
+                  </button>
+                  <button
+                    onClick={() => deleteCompetitor(c.id)}
+                    className="text-xs text-red-500 hover:text-red-400"
+                  >
+                    삭제
+                  </button>
+                </div>
+              </div>
+
+              {/* Expanded analysis results */}
+              {expandedId === c.id && c.analyses.length > 0 && (
+                <div className="border-t border-gray-700 p-4 space-y-3">
+                  {c.analyses.slice(0, 3).map((a) => {
+                    const r = a.results;
+                    return (
+                      <div key={a.id} className="text-sm space-y-2">
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={`text-xs px-2 py-0.5 rounded font-mono ${
+                              r.verdict === "Pass"
+                                ? "bg-green-900 text-green-300"
+                                : r.verdict === "Partial"
+                                ? "bg-yellow-900 text-yellow-300"
+                                : "bg-red-900 text-red-300"
+                            }`}
+                          >
+                            {r.verdict}
+                          </span>
+                          {r.score != null && (
+                            <span className="text-gray-300 font-mono text-xs">{r.score}/100</span>
+                          )}
+                          <span className="text-gray-500 text-xs">
+                            {new Date(a.createdAt).toLocaleDateString("ko-KR")}
+                          </span>
+                        </div>
+                        {r.summary && <p className="text-gray-400 text-xs">{r.summary}</p>}
+                        {r.benchmarkOpportunities && r.benchmarkOpportunities.length > 0 && (
+                          <div>
+                            <div className="text-xs text-blue-400 mb-1">벤치마킹 기회</div>
+                            <ul className="space-y-0.5">
+                              {r.benchmarkOpportunities.map((o, i) => (
+                                <li key={i} className="text-xs text-gray-400">• {o}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Radar comparison chart */}
+      {radarData.length > 0 && (
+        <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <h3 className="text-sm font-medium text-white mb-4">프레임워크별 비교</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <RadarChart data={radarData}>
+              <PolarGrid stroke="#374151" />
+              <PolarAngleAxis dataKey="axis" tick={{ fill: "#9ca3af", fontSize: 11 }} />
+              <Tooltip
+                contentStyle={{ background: "#111", border: "1px solid #374151", fontSize: 12 }}
+              />
+              <Legend />
+              {selectedAnalyses.map((a, i) => {
+                const comp = competitors.find((c) => c.id === a.competitorId);
+                return comp ? (
+                  <Radar
+                    key={comp.id}
+                    name={comp.name}
+                    dataKey={comp.name}
+                    stroke={COLORS[i % COLORS.length]}
+                    fill={COLORS[i % COLORS.length]}
+                    fillOpacity={0.15}
+                  />
+                ) : null;
+              })}
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/CompetitiveDashboard.tsx
+++ b/components/CompetitiveDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { MediaUploader, type UploadedVideo } from "@/components/MediaUploader";
 import {
   RadarChart,
   Radar,
@@ -55,6 +56,8 @@ export default function CompetitiveDashboard() {
   const [uploadingFor, setUploadingFor] = useState<string | null>(null);
   const [analyzing, setAnalyzing] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [pendingImages, setPendingImages] = useState<string[]>([]);
+  const [pendingVideos, setPendingVideos] = useState<UploadedVideo[]>([]);
 
   useEffect(() => {
     fetchCompetitors();
@@ -90,31 +93,25 @@ export default function CompetitiveDashboard() {
     fetchCompetitors();
   }
 
-  function handleFileUpload(competitorId: string, files: FileList | null) {
-    if (!files || files.length === 0) return;
-    setUploadingFor(competitorId);
-    const promises = Array.from(files).slice(0, 8).map(
-      (f) =>
-        new Promise<string>((resolve) => {
-          const reader = new FileReader();
-          reader.onload = (e) => resolve(e.target?.result as string);
-          reader.readAsDataURL(f);
-        })
-    );
-    Promise.all(promises).then(async (screenshots) => {
-      setAnalyzing(competitorId);
-      setUploadingFor(null);
-      try {
-        await fetch(`/api/competitors/${competitorId}/analyze`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ screenshots, frameworks: [] }),
-        });
-        fetchCompetitors();
-      } finally {
-        setAnalyzing(null);
-      }
-    });
+  async function analyzeCompetitor(competitorId: string) {
+    const videoFrames = pendingVideos.flatMap((v) => v.frames.map((f) => f.base64));
+    const allImages = [...pendingImages, ...videoFrames];
+    if (allImages.length === 0) return;
+
+    setAnalyzing(competitorId);
+    setUploadingFor(null);
+    setPendingImages([]);
+    setPendingVideos([]);
+    try {
+      await fetch(`/api/competitors/${competitorId}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ screenshots: allImages, frameworks: [] }),
+      });
+      fetchCompetitors();
+    } finally {
+      setAnalyzing(null);
+    }
   }
 
   // Build radar chart data from selected analyses
@@ -236,17 +233,21 @@ export default function CompetitiveDashboard() {
                       비교
                     </button>
                   )}
-                  <label className={`text-xs px-2 py-1 rounded border border-gray-600 text-gray-400 hover:border-gray-400 cursor-pointer transition-colors ${analyzing === c.id ? "opacity-50" : ""}`}>
-                    {analyzing === c.id ? "분석중..." : uploadingFor === c.id ? "업로드중..." : "스크린샷 분석"}
-                    <input
-                      type="file"
-                      accept="image/*"
-                      multiple
-                      className="hidden"
-                      disabled={!!analyzing}
-                      onChange={(e) => handleFileUpload(c.id, e.target.files)}
-                    />
-                  </label>
+                  <button
+                    onClick={() => {
+                      if (uploadingFor === c.id) {
+                        setUploadingFor(null);
+                      } else {
+                        setUploadingFor(c.id);
+                        setPendingImages([]);
+                        setPendingVideos([]);
+                      }
+                    }}
+                    disabled={!!analyzing}
+                    className="text-xs px-2 py-1 rounded border border-gray-600 text-gray-400 hover:border-gray-400 cursor-pointer transition-colors disabled:opacity-50"
+                  >
+                    {analyzing === c.id ? "분석중..." : "스크린샷 분석"}
+                  </button>
                   <button
                     onClick={() => setExpandedId(expandedId === c.id ? null : c.id)}
                     className="text-xs px-2 py-1 rounded border border-gray-700 text-gray-400 hover:border-gray-500"
@@ -261,6 +262,31 @@ export default function CompetitiveDashboard() {
                   </button>
                 </div>
               </div>
+
+              {/* Media upload expansion */}
+              {uploadingFor === c.id && (
+                <div className="border-t border-gray-700 p-4 space-y-3">
+                  <MediaUploader
+                    images={pendingImages}
+                    videos={pendingVideos}
+                    onImagesChange={setPendingImages}
+                    onVideosChange={setPendingVideos}
+                    maxImages={8}
+                    maxVideos={2}
+                    uploadZoneId={`competitor-upload-${c.id}`}
+                  />
+                  <button
+                    onClick={() => analyzeCompetitor(c.id)}
+                    disabled={pendingImages.length === 0 && pendingVideos.length === 0}
+                    className="w-full py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm rounded transition-colors"
+                  >
+                    {(() => {
+                      const frameCount = pendingVideos.flatMap((v) => v.frames).length;
+                      return `분석 시작 (${pendingImages.length + frameCount}장)`;
+                    })()}
+                  </button>
+                </div>
+              )}
 
               {/* Expanded analysis results */}
               {expandedId === c.id && c.analyses.length > 0 && (

--- a/components/SimulationPanel.tsx
+++ b/components/SimulationPanel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import type { FrameworkResult } from "@/lib/frameworks";
+
+interface SimulationResult {
+  before: FrameworkResult[];
+  after: FrameworkResult[];
+  delta: { frameworkId: string; scoreDelta: number; rationale: string }[];
+  abTestWorth: boolean;
+  abTestRationale: string;
+  estimatedImpact: {
+    retention: string;
+    arpdau: string;
+    risk: string;
+  };
+}
+
+interface SimulationPanelProps {
+  originalResults: FrameworkResult[];
+  onClose?: () => void;
+}
+
+export default function SimulationPanel({
+  originalResults,
+  onClose,
+}: SimulationPanelProps) {
+  const [hypothesis, setHypothesis] = useState("");
+  const [changeDescription, setChangeDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runSimulation() {
+    if (!hypothesis.trim() || !changeDescription.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/simulate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ originalResults, hypothesis, changeDescription }),
+      });
+      if (!res.ok) throw new Error("Simulation failed");
+      const data = await res.json();
+      setResult(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-gray-900 border border-gray-700 rounded-lg p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-white">플로우 변경 시뮬레이션</h3>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 text-sm"
+          >
+            닫기
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">가설</label>
+          <input
+            value={hypothesis}
+            onChange={(e) => setHypothesis(e.target.value)}
+            placeholder="예: 광고 직후에 스트릭 보너스 팝업을 보여주면?"
+            className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">
+            구체적 변경 내용
+          </label>
+          <textarea
+            value={changeDescription}
+            onChange={(e) => setChangeDescription(e.target.value)}
+            rows={2}
+            placeholder="어떤 화면에서 무엇을 어떻게 바꾸는지 상세히 설명"
+            className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 resize-none"
+          />
+        </div>
+        <button
+          onClick={runSimulation}
+          disabled={loading || !hypothesis.trim() || !changeDescription.trim()}
+          className="w-full py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm rounded transition-colors"
+        >
+          {loading ? "시뮬레이션 중..." : "시뮬레이션 실행"}
+        </button>
+      </div>
+
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+
+      {result && (
+        <div className="space-y-4 pt-2 border-t border-gray-700">
+          {/* A/B Test recommendation */}
+          <div
+            className={`flex items-center gap-2 px-3 py-2 rounded text-sm ${
+              result.abTestWorth
+                ? "bg-green-900/40 border border-green-800 text-green-300"
+                : "bg-yellow-900/40 border border-yellow-800 text-yellow-300"
+            }`}
+          >
+            <span>
+              {result.abTestWorth
+                ? "✓ A/B 테스트 권장"
+                : "△ A/B 테스트 비권장"}
+            </span>
+          </div>
+          {result.abTestRationale && (
+            <p className="text-xs text-gray-400">{result.abTestRationale}</p>
+          )}
+
+          {/* Score deltas */}
+          {result.delta.length > 0 && (
+            <div>
+              <div className="text-xs text-gray-500 mb-2">
+                프레임워크별 점수 변화
+              </div>
+              <div className="space-y-2">
+                {result.delta.map((d) => (
+                  <div key={d.frameworkId} className="flex items-start gap-3">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-gray-300 font-mono">
+                          {d.frameworkId}
+                        </span>
+                        <span
+                          className={`text-xs font-mono font-bold ${
+                            d.scoreDelta > 0
+                              ? "text-green-400"
+                              : d.scoreDelta < 0
+                              ? "text-red-400"
+                              : "text-gray-400"
+                          }`}
+                        >
+                          {d.scoreDelta > 0
+                            ? `+${d.scoreDelta}`
+                            : d.scoreDelta}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {d.rationale}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Impact estimates */}
+          {result.estimatedImpact && (
+            <div>
+              <div className="text-xs text-gray-500 mb-2">예상 지표 영향</div>
+              <div className="grid grid-cols-1 gap-2">
+                {result.estimatedImpact.retention && (
+                  <div className="bg-gray-800 rounded px-3 py-2 text-xs">
+                    <span className="text-blue-400">리텐션</span>
+                    <span className="text-gray-300 ml-2">
+                      {result.estimatedImpact.retention}
+                    </span>
+                  </div>
+                )}
+                {result.estimatedImpact.arpdau && (
+                  <div className="bg-gray-800 rounded px-3 py-2 text-xs">
+                    <span className="text-yellow-400">ARPDAU</span>
+                    <span className="text-gray-300 ml-2">
+                      {result.estimatedImpact.arpdau}
+                    </span>
+                  </div>
+                )}
+                {result.estimatedImpact.risk && (
+                  <div className="bg-gray-800 rounded px-3 py-2 text-xs">
+                    <span className="text-red-400">리스크</span>
+                    <span className="text-gray-300 ml-2">
+                      {result.estimatedImpact.risk}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/calibration.ts
+++ b/lib/calibration.ts
@@ -1,0 +1,126 @@
+export type SeverityLevel = 0 | 1 | 2 | 3 | 4;
+
+export interface CalibrationRecord {
+  id: string;
+  analysisId: string;
+  criterionId: string;
+  predictedSeverity: SeverityLevel;
+  actualMetric: string;
+  actualValue: number;
+  accuracy: "accurate" | "overestimated" | "underestimated";
+  deviation: number;
+  calibratedAt: Date;
+}
+
+// Severity → metric threshold mapping
+// Each criterion maps to an observable metric and what range = what severity
+export const METRIC_MAPPING: Record<
+  string,
+  {
+    metricLabel: string;
+    thresholds: Record<number, [number, number]>; // severity → [min, max]
+  }
+> = {
+  pre_ad_priming: {
+    metricLabel: "광고 시작 직전 화면 도달률",
+    thresholds: {
+      0: [0.8, 1],
+      1: [0.6, 0.8],
+      2: [0.4, 0.6],
+      3: [0.2, 0.4],
+      4: [0, 0.2],
+    },
+  },
+  post_ad_payoff: {
+    metricLabel: "광고 후 앱 잔존율",
+    thresholds: {
+      0: [0.85, 1],
+      1: [0.7, 0.85],
+      2: [0.55, 0.7],
+      3: [0.35, 0.55],
+      4: [0, 0.35],
+    },
+  },
+  daily_earning_visibility: {
+    metricLabel: "홈 화면 인게이지먼트율",
+    thresholds: {
+      0: [0.7, 1],
+      1: [0.55, 0.7],
+      2: [0.4, 0.55],
+      3: [0.25, 0.4],
+      4: [0, 0.25],
+    },
+  },
+  goal_gradient: {
+    metricLabel: "교환 페이지 방문율",
+    thresholds: {
+      0: [0.3, 1],
+      1: [0.2, 0.3],
+      2: [0.1, 0.2],
+      3: [0.05, 0.1],
+      4: [0, 0.05],
+    },
+  },
+  streak_continuity: {
+    metricLabel: "D7 리텐션율",
+    thresholds: {
+      0: [0.5, 1],
+      1: [0.35, 0.5],
+      2: [0.2, 0.35],
+      3: [0.1, 0.2],
+      4: [0, 0.1],
+    },
+  },
+  ad_completion_rate: {
+    metricLabel: "광고 시청 완료율",
+    thresholds: {
+      0: [0.8, 1],
+      1: [0.65, 0.8],
+      2: [0.5, 0.65],
+      3: [0.3, 0.5],
+      4: [0, 0.3],
+    },
+  },
+};
+
+export function calculateAccuracy(
+  predicted: SeverityLevel,
+  metricKey: string,
+  actualValue: number
+): CalibrationRecord["accuracy"] {
+  const mapping = METRIC_MAPPING[metricKey];
+  if (!mapping) return "accurate";
+
+  const range = mapping.thresholds[predicted];
+  if (!range) return "accurate";
+
+  const [min, max] = range;
+  if (actualValue >= min && actualValue <= max) return "accurate";
+  if (actualValue > max) return "overestimated"; // AI rated it as more severe than it was
+  return "underestimated"; // AI rated it as less severe than it was
+}
+
+export function calculateDeviation(
+  predicted: SeverityLevel,
+  metricKey: string,
+  actualValue: number
+): number {
+  const mapping = METRIC_MAPPING[metricKey];
+  if (!mapping) return 0;
+
+  // Find which severity level best matches the actual value
+  let bestSeverity = predicted;
+  let bestDistance = Infinity;
+
+  for (const [sev, range] of Object.entries(mapping.thresholds)) {
+    const [min, max] = range;
+    const midpoint = (min + max) / 2;
+    const dist = Math.abs(actualValue - midpoint);
+    if (dist < bestDistance) {
+      bestDistance = dist;
+      bestSeverity = Number(sev) as SeverityLevel;
+    }
+  }
+
+  return Math.abs(predicted - bestSeverity);
+}

--- a/lib/figma/comments.ts
+++ b/lib/figma/comments.ts
@@ -1,0 +1,45 @@
+export interface FigmaCommentParams {
+  fileKey: string;
+  nodeId: string;
+  message: string;
+  accessToken: string;
+}
+
+export async function postFigmaComment(params: FigmaCommentParams): Promise<unknown> {
+  const response = await fetch(
+    `https://api.figma.com/v1/files/${params.fileKey}/comments`,
+    {
+      method: "POST",
+      headers: {
+        "X-Figma-Token": params.accessToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: params.message,
+        comment_pin: {
+          node_id: params.nodeId,
+          node_offset: { x: 0, y: 0 },
+        },
+      }),
+    }
+  );
+  return response.json();
+}
+
+export function formatFindingAsComment(
+  finding: {
+    severity: number;
+    finding: string;
+    location: string;
+    suggestion: string;
+    criterionId?: string;
+  },
+  frameworkName: string
+): string {
+  const severityEmoji = ["✅", "💡", "⚠️", "🔴", "🚨"][finding.severity] ?? "⚠️";
+  return `${severityEmoji} [Simulo/${frameworkName}]
+발견: ${finding.finding}
+위치: ${finding.location}
+개선 제안: ${finding.suggestion}
+심각도: ${finding.severity}/4`;
+}

--- a/lib/notifications/slack.ts
+++ b/lib/notifications/slack.ts
@@ -1,0 +1,28 @@
+export type SlackNotificationType =
+  | "analysis_complete"
+  | "competitor_alert"
+  | "calibration_drift"
+  | "weekly_digest";
+
+export async function sendSlackNotification(params: {
+  webhookUrl: string;
+  type: SlackNotificationType;
+  data: Record<string, unknown>;
+}): Promise<void> {
+  const templates: Record<SlackNotificationType, (d: Record<string, unknown>) => string> = {
+    analysis_complete: (d) =>
+      `📊 *Simulo 분석 완료*\n화면: ${d.screenName}\n전체 점수: ${d.overallScore}/100\n최우선 이슈: ${d.topPriority}`,
+    competitor_alert: (d) =>
+      `🔔 *경쟁사 변화 감지*\n${d.competitorName}: ${d.alertMessage}\n대응 권장: ${d.recommendation}`,
+    calibration_drift: (d) =>
+      `⚠️ *캘리브레이션 드리프트*\n기준 [${d.criterionId}]의 예측 정확도가 ${d.accuracy}%로 하락\n자동 보정이 적용되었습니다.`,
+    weekly_digest: (d) =>
+      `📅 *주간 Simulo 리포트*\n분석 ${d.analysisCount}건 | 경쟁 격차 변화: ${d.gapDelta}\n이번 주 핵심: ${d.keyInsight}`,
+  };
+
+  await fetch(params.webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: templates[params.type](params.data) }),
+  });
+}

--- a/lib/prompt-calibration.ts
+++ b/lib/prompt-calibration.ts
@@ -1,0 +1,84 @@
+import type { CalibrationRecord, SeverityLevel } from "./calibration";
+
+export interface CalibrationAdjustment {
+  criterionId: string;
+  direction: "raise" | "lower";
+  magnitude: "slight" | "moderate" | "significant";
+  sampleSize: number;
+  accuracyRate: number;
+  generatedAt: Date;
+}
+
+function groupBy<T>(arr: T[], key: keyof T): Record<string, T[]> {
+  return arr.reduce(
+    (acc, item) => {
+      const k = String(item[key]);
+      if (!acc[k]) acc[k] = [];
+      acc[k].push(item);
+      return acc;
+    },
+    {} as Record<string, T[]>
+  );
+}
+
+export function analyzeCalibrationTrend(
+  records: CalibrationRecord[]
+): CalibrationAdjustment[] {
+  const grouped = groupBy(records, "criterionId");
+  const adjustments: CalibrationAdjustment[] = [];
+
+  for (const [criterionId, group] of Object.entries(grouped)) {
+    if (group.length < 5) continue; // need at least 5 data points
+
+    const overCount = group.filter((r) => r.accuracy === "overestimated").length;
+    const underCount = group.filter((r) => r.accuracy === "underestimated").length;
+    const accurateCount = group.filter((r) => r.accuracy === "accurate").length;
+    const total = group.length;
+    const accuracyRate = accurateCount / total;
+
+    if (overCount / total > 0.6) {
+      adjustments.push({
+        criterionId,
+        direction: "lower",
+        magnitude: overCount / total > 0.8 ? "significant" : "moderate",
+        sampleSize: total,
+        accuracyRate,
+        generatedAt: new Date(),
+      });
+    } else if (underCount / total > 0.6) {
+      adjustments.push({
+        criterionId,
+        direction: "raise",
+        magnitude: underCount / total > 0.8 ? "significant" : "moderate",
+        sampleSize: total,
+        accuracyRate,
+        generatedAt: new Date(),
+      });
+    }
+  }
+
+  return adjustments;
+}
+
+export function buildCalibrationDirective(
+  adjustments: CalibrationAdjustment[]
+): string {
+  if (adjustments.length === 0) return "";
+
+  const lines = adjustments.map((adj) => {
+    const dirText =
+      adj.direction === "raise"
+        ? `이 기준의 심각도를 실제보다 낮게 평가하는 경향이 있습니다. 더 엄격하게 평가하세요. (${adj.magnitude})`
+        : `이 기준의 심각도를 실제보다 높게 평가하는 경향이 있습니다. 더 관대하게 평가하세요. (${adj.magnitude})`;
+    return `- [${adj.criterionId}]: ${dirText} (보정 근거: ${adj.sampleSize}건, 정확도: ${Math.round(adj.accuracyRate * 100)}%)`;
+  });
+
+  return `
+## 캘리브레이션 보정 (실측 데이터 기반)
+아래 기준들은 과거 분석에서 실측과 차이가 있었습니다. 보정 방향을 참고하세요:
+${lines.join("\n")}
+`;
+}
+
+// Re-export SeverityLevel for convenience
+export type { SeverityLevel };

--- a/lib/prompts/competitor.ts
+++ b/lib/prompts/competitor.ts
@@ -1,0 +1,37 @@
+import type { FrameworkResult } from "../frameworks";
+
+export function buildCompetitorSystemPrompt(competitorName: string): string {
+  return `지금 분석하는 화면은 야핏무브가 아닌 경쟁사 "${competitorName}"의 앱 화면입니다.
+야핏무브와 동일한 평가 기준으로 분석하되, 추가로:
+1. 이 경쟁사가 야핏무브보다 잘하고 있는 점을 명시하세요.
+2. 이 경쟁사가 야핏무브보다 못하고 있는 점을 명시하세요.
+3. 야핏무브가 이 경쟁사로부터 벤치마킹할 수 있는 구체적 요소를 제안하세요.`;
+}
+
+export function buildCompetitorComparePrompt(
+  ourResults: FrameworkResult[],
+  competitorResults: FrameworkResult[],
+  competitorName: string
+): string {
+  return `## 야핏무브 vs ${competitorName} 비교 분석
+
+### 야핏무브 프레임워크 결과
+${JSON.stringify(ourResults, null, 2)}
+
+### ${competitorName} 프레임워크 결과
+${JSON.stringify(competitorResults, null, 2)}
+
+### 비교 지시
+1. 프레임워크별로 두 앱의 점수 차이를 분석하세요.
+2. 야핏무브가 앞서는 영역과 뒤처지는 영역을 구분하세요.
+3. 가장 시급하게 개선해야 할 격차 3가지를 우선순위 순으로 제시하세요.
+4. 각 격차에 대한 구체적인 개선 방향을 제시하세요.
+
+### 응답 형식 (JSON)
+{
+  "leading": [{ "frameworkId": "...", "gap": 숫자, "insight": "..." }],
+  "lagging": [{ "frameworkId": "...", "gap": 숫자, "insight": "..." }],
+  "topPriorities": [{ "rank": 1, "area": "...", "currentGap": 숫자, "recommendation": "..." }],
+  "overallVerdict": "..."
+}`;
+}

--- a/lib/prompts/economy-sim.ts
+++ b/lib/prompts/economy-sim.ts
@@ -1,0 +1,43 @@
+export interface EconomyVariables {
+  pointsPerStep: number;
+  exchangeThreshold: number;
+  dailyAdSlots: number;
+  streakBonusMultiplier: number;
+  adRewardPoints: number;
+  pointExpiryDays: number;
+}
+
+export function buildEconomySimPrompt(
+  currentVars: EconomyVariables,
+  proposedVars: EconomyVariables
+): string {
+  return `## 리워드 이코노미 시뮬레이션
+
+### 현재 설정
+${JSON.stringify(currentVars, null, 2)}
+
+### 제안 설정
+${JSON.stringify(proposedVars, null, 2)}
+
+### 경쟁사 기준점
+- 돈이돼지: 1포인트=1원, 무제한 적립, 수수료 무료 출금
+- 머니워크: 글로벌 기프트카드 교환, 다채널(걷기+식사+수면) 적립
+
+### 시뮬레이션 지시
+제안 설정이 적용되었을 때:
+1. D1/D7/D30 리텐션 변화 예측 (현재 대비 +/-%)
+2. ARPDAU 변화 예측 (세션당 광고 노출 × 유저 체류 기반)
+3. 월간 포인트 교환 전환율 변화
+4. 경쟁사 대비 포지셔닝 변화
+5. 리스크 (포인트 인플레이션, 마진 압박 등)
+
+### 응답 형식 (JSON)
+{
+  "retentionImpact": { "d1": "+2%", "d7": "+5%", "d30": "+3%" },
+  "arpdauImpact": "+8% (세션 길이 증가로 광고 1회 추가 노출)",
+  "exchangeRateImpact": "+12% (임계값 하락으로 교환 접근성 향상)",
+  "competitivePosition": "돈이돼지 1:1 대비 여전히 불리하나, 스트릭 보너스로 차별화",
+  "risks": ["포인트 인플레이션으로 6개월 후 마진 압박 가능"],
+  "recommendation": "2주 A/B 테스트 후 점진 적용 권장"
+}`;
+}

--- a/lib/prompts/heuristic.ts
+++ b/lib/prompts/heuristic.ts
@@ -6,6 +6,7 @@ import { FRAMEWORK_MAP, getFrameworksByCategory } from "@/lib/frameworks";
 interface HeuristicSystemPromptParams {
   frameworkIds: string[];
   language: "ko" | "en";
+  calibrationDirective?: string;
 }
 
 /**
@@ -13,7 +14,7 @@ interface HeuristicSystemPromptParams {
  * Claude에게 frameworkResults를 JSON에 포함하도록 지시한다.
  */
 export function buildHeuristicLayer(params: HeuristicSystemPromptParams): string {
-  const { frameworkIds, language } = params;
+  const { frameworkIds, language, calibrationDirective } = params;
   const isKo = language === "ko";
 
   const byCategory = getFrameworksByCategory(frameworkIds);
@@ -87,7 +88,7 @@ export function buildHeuristicLayer(params: HeuristicSystemPromptParams): string
 
   lines.push(jsonInstruction);
 
-  return lines.join("\n");
+  return lines.join("\n") + (calibrationDirective ?? "");
 }
 
 /**

--- a/lib/prompts/review-analysis.ts
+++ b/lib/prompts/review-analysis.ts
@@ -1,0 +1,30 @@
+import type { Review } from "../store-research";
+
+export function buildReviewAnalysisPrompt(
+  competitorName: string,
+  reviews: Review[]
+): string {
+  return `다음은 "${competitorName}" 앱의 최근 사용자 리뷰 ${reviews.length}건입니다.
+
+## 분석 지시
+1. 부정 리뷰에서 반복되는 불만을 클러스터링하세요 (최대 5개 클러스터).
+2. 긍정 리뷰에서 반복되는 만족 요인을 클러스터링하세요 (최대 5개 클러스터).
+3. 각 클러스터에 대해 야핏무브가 선점/개선할 수 있는 기회를 제안하세요.
+4. 업데이트 노트에서 새로 추가된 기능이 있으면 야핏무브 대응 필요 여부를 판단하세요.
+
+## 응답 형식 (JSON)
+{
+  "negativePatterns": [
+    { "pattern": "패턴 설명", "frequency": 리뷰수, "yafitOpportunity": "야핏무브 기회" }
+  ],
+  "positivePatterns": [
+    { "pattern": "패턴 설명", "frequency": 리뷰수, "yafitRisk": "야핏무브에 이것이 없으면 리스크" }
+  ],
+  "featureAlerts": [
+    { "feature": "새 기능", "impact": "high", "recommendation": "야핏무브 대응 방향" }
+  ]
+}
+
+## 리뷰 데이터
+${reviews.map((r) => `[${r.rating}★] ${r.text}`).join("\n")}`;
+}

--- a/lib/prompts/simulation.ts
+++ b/lib/prompts/simulation.ts
@@ -1,0 +1,44 @@
+import type { FrameworkResult } from "../frameworks";
+
+export function buildSimulationPrompt(
+  originalResults: FrameworkResult[],
+  hypothesis: string,
+  changeDescription: string
+): string {
+  return `## 플로우 변경 시뮬레이션
+
+### 현재 상태 (Before)
+${JSON.stringify(originalResults, null, 2)}
+
+### 제안된 변경
+가설: "${hypothesis}"
+구체적 변경: ${changeDescription}
+
+### 시뮬레이션 지시
+1. 위 변경이 적용되었다고 가정하고, 각 프레임워크의 점수가 어떻게 변할지 예측하세요.
+2. 각 프레임워크의 점수 변화에 대한 근거를 제시하세요.
+3. 이 변경이 A/B 테스트할 가치가 있는지 판단하세요.
+4. 예상 리텐션/ARPDAU 영향을 추정하세요.
+
+### 주의
+- 낙관적 편향을 피하세요. 변경에 따른 부작용(광고 노출 감소, 인지 부하 증가 등)도 반드시 고려하세요.
+- 점수 변화는 현실적 범위(±1~15점) 내에서 추정하세요.
+- "해볼 만하다"는 결론을 내리더라도 리스크를 명시하세요.
+
+### 응답 형식 (JSON)
+{
+  "afterResults": [
+    { "frameworkId": "...", "frameworkName": "...", "overallScore": 0, "findings": [] }
+  ],
+  "deltas": [
+    { "frameworkId": "...", "scoreDelta": 0, "rationale": "..." }
+  ],
+  "abTestWorth": true,
+  "abTestRationale": "...",
+  "estimatedImpact": {
+    "retention": "D1 리텐션 +2~5% 예상",
+    "arpdau": "ARPDAU 변화 미미",
+    "risk": "광고 시청 완료율 하락 리스크 낮음"
+  }
+}`;
+}

--- a/lib/prompts/ux-writing.ts
+++ b/lib/prompts/ux-writing.ts
@@ -1,0 +1,54 @@
+export function buildUXWritingPrompt(
+  issueContext: string,
+  currentCopy: string | undefined,
+  screenContext: string,
+  tones: string[]
+): string {
+  return `## UX 라이팅 제안
+
+### 맥락
+- 화면: ${screenContext}
+- 발견된 이슈: ${issueContext}
+${currentCopy ? `- 현재 카피: "${currentCopy}"` : "- 현재 카피: 없음 (신규)"}
+
+### 도메인 규칙
+이 앱은 앱테크(만보기 리워드) 앱이다. 카피의 목적은:
+1. 포인트 적립의 가치를 체감하게 하기
+2. 재방문 동기를 심어주기
+3. 광고 스트레스를 완충하기
+4. 교환 목표까지의 여정을 즐겁게 만들기
+
+경쟁사 카피 톤 참고:
+- 머니워크: "Walk to get healthy & earn rewards" (건강+보상 병행)
+- 돈이돼지: "누르면 누른 만큼 버는 정직한 앱테크" (직관적, 정직 강조)
+
+### 생성 지시
+아래 톤 각각에 대해 대안 카피를 1개씩 작성하세요.
+요청된 톤: ${tones.join(", ")}
+
+각 카피는:
+- 15자 이내 (모바일 화면 기준)
+- 한국어 자연스러운 구어체
+- 해당 톤의 특성이 명확하게 드러나야 함
+
+### 응답 형식 (JSON)
+{
+  "variants": [
+    {
+      "tone": "톤 ID",
+      "toneLabel": "톤 한글명",
+      "copy": "제안 카피",
+      "rationale": "왜 이 카피가 효과적인지",
+      "expectedEffect": "예상 지표 영향"
+    }
+  ]
+}`;
+}
+
+export const TONE_LABELS: Record<string, string> = {
+  urgent: "긴급형",
+  friendly: "친근형",
+  gamified: "게이미피케이션형",
+  minimal: "미니멀형",
+  trust: "신뢰형",
+};

--- a/lib/store-research.ts
+++ b/lib/store-research.ts
@@ -1,0 +1,50 @@
+export interface StoreData {
+  appId: string;
+  platform: "ios" | "android";
+  rating: number;
+  ratingCount: number;
+  recentReviews: Review[];
+  recentUpdates: UpdateNote[];
+  fetchedAt: Date;
+}
+
+export interface Review {
+  id: string;
+  rating: number;
+  text: string;
+  date: Date;
+  language: string;
+}
+
+export interface UpdateNote {
+  version: string;
+  date: Date;
+  notes: string;
+}
+
+/**
+ * Parse CSV-formatted review data (MVP approach — manual upload)
+ * Expected CSV format: id,rating,text,date,language
+ */
+export function parseReviewCSV(csvText: string): Review[] {
+  const lines = csvText.trim().split("\n");
+  const header = lines[0].split(",");
+  const idxMap = {
+    id: header.indexOf("id"),
+    rating: header.indexOf("rating"),
+    text: header.indexOf("text"),
+    date: header.indexOf("date"),
+    language: header.indexOf("language"),
+  };
+
+  return lines.slice(1).map((line, i) => {
+    const cols = line.split(",");
+    return {
+      id: idxMap.id >= 0 ? cols[idxMap.id] : String(i),
+      rating: idxMap.rating >= 0 ? Number(cols[idxMap.rating]) : 3,
+      text: idxMap.text >= 0 ? cols[idxMap.text] : line,
+      date: idxMap.date >= 0 ? new Date(cols[idxMap.date]) : new Date(),
+      language: idxMap.language >= 0 ? cols[idxMap.language] : "ko",
+    };
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,3 +61,36 @@ model PluginAuthSession {
   tokens    String
   createdAt DateTime @default(now())
 }
+
+model Competitor {
+  id        String               @id @default(cuid())
+  name      String
+  url       String?
+  logoUrl   String?
+  createdAt DateTime             @default(now())
+  analyses  CompetitorAnalysis[]
+  snapshots StoreSnapshot[]
+}
+
+model CompetitorAnalysis {
+  id           String     @id @default(cuid())
+  competitorId String
+  competitor   Competitor @relation(fields: [competitorId], references: [id], onDelete: Cascade)
+  screenshots  Json       // base64 image array
+  frameworks   String[]   // framework IDs used
+  results      Json       // FrameworkResult[] serialized
+  createdAt    DateTime   @default(now())
+}
+
+model StoreSnapshot {
+  id             String     @id @default(cuid())
+  competitorId   String
+  competitor     Competitor @relation(fields: [competitorId], references: [id], onDelete: Cascade)
+  platform       String     // 'ios' | 'android'
+  rating         Float
+  ratingCount    Int
+  reviews        Json       // Review[]
+  updateNotes    Json       // UpdateNote[]
+  analysisResult Json?      // Claude analysis result
+  fetchedAt      DateTime   @default(now())
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,3 +94,31 @@ model StoreSnapshot {
   analysisResult Json?      // Claude analysis result
   fetchedAt      DateTime   @default(now())
 }
+
+model CalibrationRecord {
+  id                String   @id @default(cuid())
+  analysisId        String
+  criterionId       String
+  predictedSeverity Int
+  actualMetric      String
+  actualValue       Float
+  accuracy          String   // 'accurate' | 'overestimated' | 'underestimated'
+  deviation         Float
+  calibratedAt      DateTime @default(now())
+}
+
+model AnalyticsConnection {
+  id          String   @id @default(cuid())
+  provider    String   // 'ga4' | 'mixpanel' | 'amplitude' | 'manual'
+  credentials Json     // encrypted
+  propertyId  String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+}
+
+model SlackConfig {
+  id         String   @id @default(cuid())
+  webhookUrl String
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+}


### PR DESCRIPTION
## Summary

- **CompetitiveDashboard 업그레이드**: 기존 `<input type="file">` 버튼을 `MediaUploader` 컴포넌트로 교체. 경쟁사별 인라인 확장 UI로 이미지+영상 업로드 지원. 영상 프레임은 스크린샷과 병합되어 분석 API로 전달됨.
- **`/api/competitors/quick-analyze`**: DB 저장 없이 경쟁사명+스크린샷만으로 Claude 분석 실행하는 엔드포인트 신설.
- **`/competitor` 페이지**: 경쟁사 등록 없이 바로 분석 가능한 독립 페이지. 분석 결과 인라인 표시 + "경쟁사로 등록" 버튼 제공.

## Test plan

- [ ] CompetitiveDashboard에서 "스크린샷 분석" 버튼 클릭 → 인라인 MediaUploader 토글 확인
- [ ] 이미지 업로드 후 "분석 시작" → `/api/competitors/[id]/analyze` 정상 호출 확인
- [ ] 영상 업로드 → 프레임 추출 → 분석 시 프레임 포함 확인
- [ ] `/competitor` 접속 → 이름 입력 + 이미지 업로드 → 분석 결과 표시 확인
- [ ] `/competitor`에서 "경쟁사로 등록" → `/api/competitors` POST 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)